### PR TITLE
v0.5.0-alpha.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 
+## v0.5.0-alpha.19 (2021-10-22)
+
+#### Features - Code Generation
+* `proto-nexus`, `protoc-gen-nexus`
+  * [#169](https://github.com/proto-graphql/proto-nexus/pull/169) Generate proto metadata as extensions ([@izumin5210](https://github.com/izumin5210))
+
+#### Improvements - Code Generation
+* `@proto-nexus/google-protobuf`, `@proto-nexus/protobufjs`, `proto-nexus`, `protoc-gen-nexus`
+  * [#155](https://github.com/proto-graphql/proto-nexus/pull/155) Validate parseInt results for 64bit number fields ([@izumin5210](https://github.com/izumin5210))
+
+#### Dependencies
+* [#161](https://github.com/proto-graphql/proto-nexus/pull/161) build(deps): bump tar from 4.4.15 to 4.4.19 ([@dependabot[bot]](https://github.com/apps/dependabot))
+* [#164](https://github.com/proto-graphql/proto-nexus/pull/164) build(deps): bump tmpl from 1.0.4 to 1.0.5 ([@dependabot[bot]](https://github.com/apps/dependabot))
+
+#### Committers: 1
+- Masayuki Izumi ([@izumin5210](https://github.com/izumin5210))
+
 ## v0.5.0-alpha.18 (2021-08-10)
 
 #### Features - Code Generation

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0-alpha.18",
+  "version": "0.5.0-alpha.19",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/@proto-nexus/google-protobuf/package.json
+++ b/packages/@proto-nexus/google-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proto-nexus/google-protobuf",
-  "version": "0.5.0-alpha.16",
+  "version": "0.5.0-alpha.19",
   "description": "Generate DSL for GraphQL Nexus from Protocol Buffers IDL",
   "keywords": [
     "graphql",
@@ -28,7 +28,7 @@
     "module/"
   ],
   "dependencies": {
-    "proto-nexus": "^0.5.0-alpha.16"
+    "proto-nexus": "^0.5.0-alpha.19"
   },
   "peerDependencies": {
     "@types/google-protobuf": "^3.7.2",

--- a/packages/@proto-nexus/protobufjs/package.json
+++ b/packages/@proto-nexus/protobufjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proto-nexus/protobufjs",
-  "version": "0.5.0-alpha.16",
+  "version": "0.5.0-alpha.19",
   "description": "Generate DSL for GraphQL Nexus from Protocol Buffers IDL",
   "keywords": [
     "graphql",
@@ -27,7 +27,7 @@
     "module/"
   ],
   "dependencies": {
-    "proto-nexus": "^0.5.0-alpha.16"
+    "proto-nexus": "^0.5.0-alpha.19"
   },
   "peerDependencies": {
     "protobufjs": "^6.10.2"

--- a/packages/@testapis/node-native/package.json
+++ b/packages/@testapis/node-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testapis/node-native",
-  "version": "0.5.0-alpha.18",
+  "version": "0.5.0-alpha.19",
   "description": "Generated codes with protocolbuffers/protobuf's js_out",
   "private": true,
   "dependencies": {

--- a/packages/proto-nexus/package.json
+++ b/packages/proto-nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proto-nexus",
-  "version": "0.5.0-alpha.16",
+  "version": "0.5.0-alpha.19",
   "description": "Generate DSL for GraphQL Nexus from Protocol Buffers IDL",
   "keywords": [
     "graphql",

--- a/packages/protoc-gen-nexus/package.json
+++ b/packages/protoc-gen-nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protoc-gen-nexus",
-  "version": "0.5.0-alpha.18",
+  "version": "0.5.0-alpha.19",
   "description": "Generate DSL for GraphQL Nexus from Protocol Buffers IDL",
   "keywords": [
     "graphql",
@@ -27,10 +27,10 @@
     "change-case": "^4.1.2"
   },
   "devDependencies": {
-    "@proto-nexus/google-protobuf": "^0.5.0-alpha.16",
-    "@proto-nexus/protobufjs": "^0.5.0-alpha.16",
+    "@proto-nexus/google-protobuf": "^0.5.0-alpha.19",
+    "@proto-nexus/protobufjs": "^0.5.0-alpha.19",
     "@testapis/node": "^0.5.0-alpha.18",
-    "@testapis/node-native": "^0.5.0-alpha.18",
+    "@testapis/node-native": "^0.5.0-alpha.19",
     "@types/glob": "7.2.0",
     "glob": "7.2.0"
   },


### PR DESCRIPTION
## v0.5.0-alpha.19 (2021-10-22)

#### Features - Code Generation
* `proto-nexus`, `protoc-gen-nexus`
  * [#169](https://github.com/proto-graphql/proto-nexus/pull/169) Generate proto metadata as extensions ([@izumin5210](https://github.com/izumin5210))

#### Improvements - Code Generation
* `@proto-nexus/google-protobuf`, `@proto-nexus/protobufjs`, `proto-nexus`, `protoc-gen-nexus`
  * [#155](https://github.com/proto-graphql/proto-nexus/pull/155) Validate parseInt results for 64bit number fields ([@izumin5210](https://github.com/izumin5210))

#### Dependencies
* [#161](https://github.com/proto-graphql/proto-nexus/pull/161) build(deps): bump tar from 4.4.15 to 4.4.19 ([@dependabot[bot]](https://github.com/apps/dependabot))
* [#164](https://github.com/proto-graphql/proto-nexus/pull/164) build(deps): bump tmpl from 1.0.4 to 1.0.5 ([@dependabot[bot]](https://github.com/apps/dependabot))