### PR TITLE
perf(protoc-gen-pothos): swap dprint-node for oxfmt via synckit

### DIFF
--- a/.changeset/perf-protoc-gen-pothos-oxfmt.md
+++ b/.changeset/perf-protoc-gen-pothos-oxfmt.md
@@ -1,0 +1,5 @@
+---
+"protoc-gen-pothos": patch
+---
+
+perf: swap dprint-node for oxfmt via synckit for ~2x faster plugin runs

--- a/packages/protoc-gen-pothos/package.json
+++ b/packages/protoc-gen-pothos/package.json
@@ -53,7 +53,8 @@
     "@bufbuild/protoplugin": "catalog:",
     "@proto-graphql/codegen-core": "workspace:*",
     "@proto-graphql/protoc-plugin-helpers": "workspace:*",
-    "dprint-node": "catalog:"
+    "oxfmt": "^0.51.0",
+    "synckit": "^0.11.12"
   },
   "devDependencies": {
     "@pothos/core": "catalog:test",

--- a/packages/protoc-gen-pothos/src/codegen/stringify-worker.mjs
+++ b/packages/protoc-gen-pothos/src/codegen/stringify-worker.mjs
@@ -1,0 +1,25 @@
+// Plain ESM worker so `new Worker(...)` can load it without a TS loader.
+// (tsx/--import tsx does not propagate to worker_threads on Node 22.)
+import { format as oxfmtFormat } from "oxfmt";
+import { runAsWorker } from "synckit";
+
+const OPTIONS = {
+  printWidth: 80,
+  tabWidth: 2,
+  useTabs: false,
+  semi: true,
+  singleQuote: false,
+  quoteProps: "as-needed",
+  endOfLine: "lf",
+  trailingComma: "all",
+  arrowParens: "always",
+};
+
+runAsWorker(async (code) => {
+  const result = await oxfmtFormat("file.ts", code, OPTIONS);
+  const fatal = result.errors.find((e) => e.severity === "Error");
+  if (fatal) {
+    throw new Error(`oxfmt failed to format: ${fatal.message}`);
+  }
+  return result.code;
+});

--- a/packages/protoc-gen-pothos/src/codegen/stringify.ts
+++ b/packages/protoc-gen-pothos/src/codegen/stringify.ts
@@ -1,22 +1,35 @@
-import dprint from "dprint-node";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createSyncFn } from "synckit";
+
+// `formatCode` is called from `protocGenPothos.run` (a sync API enforced by
+// `@bufbuild/protoplugin`), so we wrap oxfmt's async `format` in a worker
+// thread and block via Atomics.wait. The worker is a plain ESM `.mjs` file so
+// `new Worker(...)` can load it without a TS loader — tsx's `--import tsx`
+// does not propagate into worker_threads on Node 22.
+//
+// At runtime, this module is bundled into `dist/protoc-gen-pothos.{cjs,js}`
+// (built) or runs from `src/codegen/stringify.ts` (vitest / tsx). The worker
+// is at `./codegen/stringify-worker.mjs` (built) or `./stringify-worker.mjs`
+// (source) relative to this file.
+
+// import.meta.url is available at runtime in both formats tsup emits. The
+// package's `module: commonjs` tsconfig (used only for declaration emit)
+// rejects the syntax itself, so suppress that single check.
+// @ts-ignore - `module: commonjs` (used only for declaration emit) rejects the
+// import.meta syntax; the root/vitest tsconfig with `module: esnext` accepts
+// it, so @ts-expect-error would itself error there. tsup emits both formats.
+const importMetaUrl: string = import.meta.url;
+const here = dirname(fileURLToPath(importMetaUrl));
+const candidates = [
+  resolve(here, "codegen/stringify-worker.mjs"),
+  resolve(here, "stringify-worker.mjs"),
+];
+const workerPath = candidates.find((p) => existsSync(p)) ?? candidates[0];
+
+const syncFormat = createSyncFn<(code: string) => string>(workerPath);
 
 export function formatCode(code: string): string {
-  return dprint.format("file.ts", code, {
-    lineWidth: 80,
-    indentWidth: 2,
-    useTabs: false,
-    semiColons: "always",
-    quoteStyle: "alwaysDouble",
-    quoteProps: "asNeeded",
-    newLineKind: "lf",
-    useBraces: "whenNotSingleLine",
-    bracePosition: "sameLineUnlessHanging",
-    singleBodyPosition: "maintain",
-    nextControlFlowPosition: "sameLine",
-    trailingCommas: "onlyMultiLine",
-    operatorPosition: "nextLine",
-    preferHanging: false,
-    preferSingleLine: true,
-    "arrowFunction.useParentheses": "force",
-  });
+  return syncFormat(code);
 }

--- a/packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/enumType.test.ts.snap
+++ b/packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/enumType.test.ts.snap
@@ -76,8 +76,8 @@ exports[`createEnumTypeCode > protobuf-es > 'generates code for enum with extens
 import { PrefixedEnum } from "@testapis/protobuf-es-v2/testapis/options/message_and_field/message_and_field_pb";
 import { builder } from "../../builder";
 
-export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> = builder
-  .enumType("PrefixedEnum", {
+export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> =
+  builder.enumType("PrefixedEnum", {
     values: {
       PREFIXED_FOO: {
         value: 1,
@@ -333,8 +333,8 @@ exports[`createEnumTypeCode > ts-proto > 'generates code for enum with extension
 import { PrefixedEnum } from "@testapis/ts-proto/testapis/options/message_and_field/message_and_field";
 import { builder } from "../../builder";
 
-export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> = builder
-  .enumType("PrefixedEnum", {
+export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> =
+  builder.enumType("PrefixedEnum", {
     values: {
       PREFIXED_FOO: {
         value: 1,

--- a/packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/inputObjectType.test.ts.snap
+++ b/packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/inputObjectType.test.ts.snap
@@ -169,7 +169,10 @@ export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
         type: "Boolean",
         required: true,
         extensions: {
-          protobufField: { name: "required_bool_value", typeFullName: "bool" },
+          protobufField: {
+            name: "required_bool_value",
+            typeFullName: "bool",
+          },
         },
       }),
       requiredStringValue: t.field({
@@ -316,7 +319,10 @@ export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
         type: ["Boolean"],
         required: { list: true, items: true },
         extensions: {
-          protobufField: { name: "required_bool_values", typeFullName: "bool" },
+          protobufField: {
+            name: "required_bool_values",
+            typeFullName: "bool",
+          },
         },
       }),
       requiredStringValues: t.field({
@@ -405,7 +411,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredPrimitives: t.field({
         type: PrimitivesInput$Ref,
@@ -472,10 +479,10 @@ export function MessageInput$toProto(
       ? PrimitivesInput$toProto(input.optionalPrimitives)
       : undefined,
     requiredPrimitivesList: input?.requiredPrimitivesList?.map((v) =>
-      PrimitivesInput$toProto(v)
+      PrimitivesInput$toProto(v),
     ),
     optionalPrimitivesList: input?.optionalPrimitivesList?.map((v) =>
-      PrimitivesInput$toProto(v)
+      PrimitivesInput$toProto(v),
     ),
   });
 }
@@ -566,26 +573,26 @@ export function OneofParentInput$toProto(
     normalField: input?.normalField ?? undefined,
     requiredOneofMembers: input?.requiredMessage1
       ? {
-        case: "requiredMessage1",
-        value: OneofMemberMessage1Input$toProto(input.requiredMessage1),
-      }
+          case: "requiredMessage1",
+          value: OneofMemberMessage1Input$toProto(input.requiredMessage1),
+        }
       : input?.requiredMessage2
-      ? {
-        case: "requiredMessage2",
-        value: OneofMemberMessage2Input$toProto(input.requiredMessage2),
-      }
-      : undefined,
+        ? {
+            case: "requiredMessage2",
+            value: OneofMemberMessage2Input$toProto(input.requiredMessage2),
+          }
+        : undefined,
     optionalOneofMembers: input?.optionalMessage1
       ? {
-        case: "optionalMessage1",
-        value: OneofMemberMessage1Input$toProto(input.optionalMessage1),
-      }
+          case: "optionalMessage1",
+          value: OneofMemberMessage1Input$toProto(input.optionalMessage1),
+        }
       : input?.optionalMessage2
-      ? {
-        case: "optionalMessage2",
-        value: OneofMemberMessage2Input$toProto(input.optionalMessage2),
-      }
-      : undefined,
+        ? {
+            case: "optionalMessage2",
+            value: OneofMemberMessage2Input$toProto(input.optionalMessage2),
+          }
+        : undefined,
   });
 }
 "
@@ -793,7 +800,10 @@ export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
         type: "Boolean",
         required: true,
         extensions: {
-          protobufField: { name: "required_bool_value", typeFullName: "bool" },
+          protobufField: {
+            name: "required_bool_value",
+            typeFullName: "bool",
+          },
         },
       }),
       requiredStringValue: t.field({
@@ -940,7 +950,10 @@ export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
         type: ["Boolean"],
         required: { list: true, items: true },
         extensions: {
-          protobufField: { name: "required_bool_values", typeFullName: "bool" },
+          protobufField: {
+            name: "required_bool_values",
+            typeFullName: "bool",
+          },
         },
       }),
       requiredStringValues: t.field({
@@ -1025,7 +1038,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredPrimitives: t.field({
         type: PrimitivesInput$Ref,
@@ -1092,10 +1106,10 @@ export function MessageInput$toProto(
       ? PrimitivesInput$toProto(input.optionalPrimitives)
       : undefined,
     requiredPrimitivesList: input?.requiredPrimitivesList?.map((v) =>
-      PrimitivesInput$toProto(v)
+      PrimitivesInput$toProto(v),
     ),
     optionalPrimitivesList: input?.optionalPrimitivesList?.map((v) =>
-      PrimitivesInput$toProto(v)
+      PrimitivesInput$toProto(v),
     ),
   });
 }
@@ -1182,26 +1196,26 @@ export function OneofParentInput$toProto(
     normalField: input?.normalField ?? undefined,
     requiredOneofMembers: input?.requiredMessage1
       ? {
-        case: "requiredMessage1",
-        value: OneofMemberMessage1Input$toProto(input.requiredMessage1),
-      }
+          case: "requiredMessage1",
+          value: OneofMemberMessage1Input$toProto(input.requiredMessage1),
+        }
       : input?.requiredMessage2
-      ? {
-        case: "requiredMessage2",
-        value: OneofMemberMessage2Input$toProto(input.requiredMessage2),
-      }
-      : undefined,
+        ? {
+            case: "requiredMessage2",
+            value: OneofMemberMessage2Input$toProto(input.requiredMessage2),
+          }
+        : undefined,
     optionalOneofMembers: input?.optionalMessage1
       ? {
-        case: "optionalMessage1",
-        value: OneofMemberMessage1Input$toProto(input.optionalMessage1),
-      }
+          case: "optionalMessage1",
+          value: OneofMemberMessage1Input$toProto(input.optionalMessage1),
+        }
       : input?.optionalMessage2
-      ? {
-        case: "optionalMessage2",
-        value: OneofMemberMessage2Input$toProto(input.optionalMessage2),
-      }
-      : undefined,
+        ? {
+            case: "optionalMessage2",
+            value: OneofMemberMessage2Input$toProto(input.optionalMessage2),
+          }
+        : undefined,
   });
 }
 "
@@ -1405,7 +1419,10 @@ export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
         type: "Boolean",
         required: true,
         extensions: {
-          protobufField: { name: "required_bool_value", typeFullName: "bool" },
+          protobufField: {
+            name: "required_bool_value",
+            typeFullName: "bool",
+          },
         },
       }),
       requiredStringValue: t.field({
@@ -1552,7 +1569,10 @@ export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
         type: ["Boolean"],
         required: { list: true, items: true },
         extensions: {
-          protobufField: { name: "required_bool_values", typeFullName: "bool" },
+          protobufField: {
+            name: "required_bool_values",
+            typeFullName: "bool",
+          },
         },
       }),
       requiredStringValues: t.field({
@@ -1599,7 +1619,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredPrimitives: t.field({
         type: PrimitivesInput$Ref,
@@ -1775,7 +1796,9 @@ export const ParentMessageInput$Ref: InputObjectRef<ParentMessageInput$Shape> =
       body: t.field({
         type: "String",
         required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+        extensions: {
+          protobufField: { name: "body", typeFullName: "string" },
+        },
       }),
       nested: t.field({
         type: ParentMessageNestedMessageInput$Ref,
@@ -1820,10 +1843,8 @@ export type MessagePartialInput$Shape = {
   optionalPrimitivesList?: Array<PrimitivesPartialInput$Shape> | null;
 };
 
-export const MessagePartialInput$Ref: InputObjectRef<
-  MessagePartialInput$Shape
-> = builder.inputRef<MessagePartialInput$Shape>("MessagePartialInput")
-  .implement({
+export const MessagePartialInput$Ref: InputObjectRef<MessagePartialInput$Shape> =
+  builder.inputRef<MessagePartialInput$Shape>("MessagePartialInput").implement({
     fields: (t) => ({
       requiredPrimitives: t.field({
         type: PrimitivesPartialInput$Ref,

--- a/packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/objectType.test.ts.snap
+++ b/packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/objectType.test.ts.snap
@@ -1,13 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`createObjectTypeCode > protobuf-es > 'generates code for a message with nested fields with isMessage' 1`] = `
-"import { isMessage, MessageShape } from "@bufbuild/protobuf";
+"import { MessageShape, isMessage } from "@bufbuild/protobuf";
 import { MessageSchema } from "@testapis/protobuf-es-v2/testapis/basic/scalars/scalars_pb";
 import { builder } from "../../builder";
 
-export const Message$Ref = builder.objectRef<
-  MessageShape<typeof MessageSchema>
->("Message");
+export const Message$Ref =
+  builder.objectRef<MessageShape<typeof MessageSchema>>("Message");
 builder.objectType(Message$Ref, {
   name: "Message",
   fields: (t) => ({
@@ -77,7 +76,7 @@ builder.objectType(Message$Ref, {
 `;
 
 exports[`createObjectTypeCode > protobuf-es > 'generates code for a message with oneofs with isMessage' 1`] = `
-"import { isMessage, MessageShape } from "@bufbuild/protobuf";
+"import { MessageShape, isMessage } from "@bufbuild/protobuf";
 import {
   OneofMemberMessage1,
   OneofMemberMessage2,
@@ -85,9 +84,8 @@ import {
 } from "@testapis/protobuf-es-v2/testapis/oneof/message_only/message_only_pb";
 import { builder } from "../../builder";
 
-export const OneofParent$Ref = builder.objectRef<
-  MessageShape<typeof OneofParentSchema>
->("OneofParent");
+export const OneofParent$Ref =
+  builder.objectRef<MessageShape<typeof OneofParentSchema>>("OneofParent");
 builder.objectType(OneofParent$Ref, {
   name: "OneofParent",
   fields: (t) => ({
@@ -142,13 +140,12 @@ builder.objectType(OneofParent$Ref, {
 `;
 
 exports[`createObjectTypeCode > protobuf-es > 'generates code for a simple message with isMessage' 1`] = `
-"import { isMessage, MessageShape } from "@bufbuild/protobuf";
+"import { MessageShape, isMessage } from "@bufbuild/protobuf";
 import { PrimitivesSchema } from "@testapis/protobuf-es-v2/testapis/basic/scalars/scalars_pb";
 import { builder } from "../../builder";
 
-export const Primitives$Ref = builder.objectRef<
-  MessageShape<typeof PrimitivesSchema>
->("Primitives");
+export const Primitives$Ref =
+  builder.objectRef<MessageShape<typeof PrimitivesSchema>>("Primitives");
 builder.objectType(Primitives$Ref, {
   name: "Primitives",
   fields: (t) => ({
@@ -444,13 +441,12 @@ builder.objectType(Primitives$Ref, {
 `;
 
 exports[`createObjectTypeCode > protobuf-es > 'generates code for empty message with isMessage' 1`] = `
-"import { isMessage, MessageShape } from "@bufbuild/protobuf";
+"import { MessageShape, isMessage } from "@bufbuild/protobuf";
 import { EmptyMessageSchema } from "@testapis/protobuf-es-v2/testapis/basic/empty/empty_pb";
 import { builder } from "../../builder";
 
-export const EmptyMessage$Ref = builder.objectRef<
-  MessageShape<typeof EmptyMessageSchema>
->("EmptyMessage");
+export const EmptyMessage$Ref =
+  builder.objectRef<MessageShape<typeof EmptyMessageSchema>>("EmptyMessage");
 builder.objectType(EmptyMessage$Ref, {
   name: "EmptyMessage",
   fields: (t) => ({
@@ -476,19 +472,20 @@ builder.objectType(EmptyMessage$Ref, {
 `;
 
 exports[`createObjectTypeCode > protobuf-es > 'generates code for message with squashed oneof fields with isMessage' 1`] = `
-"import { isMessage, MessageShape } from "@bufbuild/protobuf";
+"import { MessageShape, isMessage } from "@bufbuild/protobuf";
 import {
   EnumWillRename,
   PrefixedEnum,
+  PrefixedMessageSchema,
   PrefixedMessage_InnerMessage,
   PrefixedMessage_InnerMessage2,
-  PrefixedMessageSchema,
 } from "@testapis/protobuf-es-v2/testapis/options/message_and_field/message_and_field_pb";
 import { builder } from "../../builder";
 
-export const PrefixedMessage$Ref = builder.objectRef<
-  MessageShape<typeof PrefixedMessageSchema>
->("PrefixedMessage");
+export const PrefixedMessage$Ref =
+  builder.objectRef<MessageShape<typeof PrefixedMessageSchema>>(
+    "PrefixedMessage",
+  );
 builder.objectType(PrefixedMessage$Ref, {
   name: "PrefixedMessage",
   fields: (t) => ({
@@ -657,16 +654,15 @@ builder.objectType(PrefixedMessage$Ref, {
 `;
 
 exports[`createObjectTypeCode > protobuf-es > 'generates code for nested types with isMessage' 1`] = `
-"import { isMessage, MessageShape } from "@bufbuild/protobuf";
+"import { MessageShape, isMessage } from "@bufbuild/protobuf";
 import {
-  ParentMessage_NestedEnum,
   ParentMessageSchema,
+  ParentMessage_NestedEnum,
 } from "@testapis/protobuf-es-v2/testapis/basic/nested/nested_pb";
 import { builder } from "../../builder";
 
-export const ParentMessage$Ref = builder.objectRef<
-  MessageShape<typeof ParentMessageSchema>
->("ParentMessage");
+export const ParentMessage$Ref =
+  builder.objectRef<MessageShape<typeof ParentMessageSchema>>("ParentMessage");
 builder.objectType(ParentMessage$Ref, {
   name: "ParentMessage",
   fields: (t) => ({
@@ -1213,8 +1209,10 @@ builder.objectType(Message$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Message | { $type: string & {}; }).$type ===
-      "testapis.basic.scalars.Message";
+    return (
+      (source as Message | { $type: string & {} }).$type ===
+      "testapis.basic.scalars.Message"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -1269,8 +1267,10 @@ builder.objectType(OneofParent$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as OneofParent | { $type: string & {}; }).$type ===
-      "testapis.oneof.message_only.OneofParent";
+    return (
+      (source as OneofParent | { $type: string & {} }).$type ===
+      "testapis.oneof.message_only.OneofParent"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -1569,8 +1569,10 @@ builder.objectType(Primitives$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Primitives | { $type: string & {}; }).$type ===
-      "testapis.basic.scalars.Primitives";
+    return (
+      (source as Primitives | { $type: string & {} }).$type ===
+      "testapis.basic.scalars.Primitives"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -1599,8 +1601,10 @@ builder.objectType(EmptyMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as EmptyMessage | { $type: string & {}; }).$type ===
-      "testapis.basic.empty.EmptyMessage";
+    return (
+      (source as EmptyMessage | { $type: string & {} }).$type ===
+      "testapis.basic.empty.EmptyMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -1620,9 +1624,8 @@ exports[`createObjectTypeCode > ts-proto > 'generates code for nested types' 1`]
 } from "@testapis/ts-proto/testapis/basic/nested/nested";
 import { builder } from "../../builder";
 
-export const ParentMessage$Ref = builder.objectRef<ParentMessage>(
-  "ParentMessage",
-);
+export const ParentMessage$Ref =
+  builder.objectRef<ParentMessage>("ParentMessage");
 builder.objectType(ParentMessage$Ref, {
   name: "ParentMessage",
   fields: (t) => ({
@@ -1662,8 +1665,10 @@ builder.objectType(ParentMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as ParentMessage | { $type: string & {}; }).$type ===
-      "testapis.basic.nested.ParentMessage";
+    return (
+      (source as ParentMessage | { $type: string & {} }).$type ===
+      "testapis.basic.nested.ParentMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -1684,9 +1689,8 @@ exports[`createObjectTypeCode > with extensions > 'generates code for message wi
 } from "@testapis/ts-proto/testapis/options/message_and_field/message_and_field";
 import { builder } from "../../builder";
 
-export const PrefixedMessage$Ref = builder.objectRef<PrefixedMessage>(
-  "PrefixedMessage",
-);
+export const PrefixedMessage$Ref =
+  builder.objectRef<PrefixedMessage>("PrefixedMessage");
 builder.objectType(PrefixedMessage$Ref, {
   name: "PrefixedMessage",
   fields: (t) => ({
@@ -1753,7 +1757,8 @@ builder.objectType(PrefixedMessage$Ref, {
       type: PrefixedMessageSquashedMessage$Ref,
       nullable: true,
       resolve: (source) => {
-        const value = source.squashedMessage?.oneofField ??
+        const value =
+          source.squashedMessage?.oneofField ??
           source.squashedMessage?.oneofField2;
         if (value == null) {
           return null;
@@ -1842,8 +1847,10 @@ builder.objectType(PrefixedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as PrefixedMessage | { $type: string & {}; }).$type ===
-      "testapis.options.message_and_field.PrefixedMessage";
+    return (
+      (source as PrefixedMessage | { $type: string & {} }).$type ===
+      "testapis.options.message_and_field.PrefixedMessage"
+    );
   },
   extensions: {
     protobufMessage: {

--- a/packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/oneofUnionType.test.ts.snap
+++ b/packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/oneofUnionType.test.ts.snap
@@ -15,13 +15,16 @@ export const OneofParentRequiredOneofMembers$Ref = builder.unionType(
         name: "required_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "required_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "required_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "required_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "required_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },
@@ -42,17 +45,18 @@ export const PrefixedMessageSquashedMessage$Ref = builder.unionType(
           "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
         name: "SquashedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }, {
-          name: "oneof_field_2",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }],
+        fields: [
+          {
+            name: "oneof_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+          {
+            name: "oneof_field_2",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+        ],
       },
     },
   },
@@ -74,13 +78,16 @@ export const OneofParentOptionalOneofMembers$Ref = builder.unionType(
         name: "optional_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "optional_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "optional_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "optional_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "optional_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },
@@ -105,13 +112,16 @@ export const OneofParentOneofField$Ref = builder.unionType(
         name: "oneof_field",
         messageName: "OneofParent",
         package: "testapis.imports.oneof_cross_file",
-        fields: [{
-          name: "member1",
-          type: "testapis.imports.oneof_cross_file.OneofMember1",
-        }, {
-          name: "member2",
-          type: "testapis.imports.oneof_cross_file.OneofMember2",
-        }],
+        fields: [
+          {
+            name: "member1",
+            type: "testapis.imports.oneof_cross_file.OneofMember1",
+          },
+          {
+            name: "member2",
+            type: "testapis.imports.oneof_cross_file.OneofMember2",
+          },
+        ],
       },
     },
   },
@@ -134,13 +144,16 @@ export const OneofParentRequiredOneofMembers$Ref = builder.unionType(
         name: "required_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "required_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "required_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "required_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "required_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },
@@ -161,17 +174,18 @@ export const PrefixedMessageSquashedMessage$Ref = builder.unionType(
           "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
         name: "SquashedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }, {
-          name: "oneof_field_2",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }],
+        fields: [
+          {
+            name: "oneof_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+          {
+            name: "oneof_field_2",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+        ],
       },
     },
   },
@@ -193,13 +207,16 @@ export const OneofParentOptionalOneofMembers$Ref = builder.unionType(
         name: "optional_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "optional_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "optional_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "optional_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "optional_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },
@@ -222,13 +239,16 @@ export const OneofParentRequiredOneofMembers$Ref = builder.unionType(
         name: "required_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "required_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "required_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "required_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "required_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },
@@ -249,17 +269,18 @@ export const PrefixedMessageSquashedMessage$Ref = builder.unionType(
           "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
         name: "SquashedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }, {
-          name: "oneof_field_2",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }],
+        fields: [
+          {
+            name: "oneof_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+          {
+            name: "oneof_field_2",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+        ],
       },
     },
   },
@@ -281,13 +302,16 @@ export const OneofParentOptionalOneofMembers$Ref = builder.unionType(
         name: "optional_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "optional_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "optional_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "optional_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "optional_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },
@@ -312,13 +336,16 @@ export const OneofParentOneofField$Ref = builder.unionType(
         name: "oneof_field",
         messageName: "OneofParent",
         package: "testapis.imports.oneof_cross_file",
-        fields: [{
-          name: "member1",
-          type: "testapis.imports.oneof_cross_file.OneofMember1",
-        }, {
-          name: "member2",
-          type: "testapis.imports.oneof_cross_file.OneofMember2",
-        }],
+        fields: [
+          {
+            name: "member1",
+            type: "testapis.imports.oneof_cross_file.OneofMember1",
+          },
+          {
+            name: "member2",
+            type: "testapis.imports.oneof_cross_file.OneofMember2",
+          },
+        ],
       },
     },
   },

--- a/packages/protoc-gen-pothos/tsconfig.json
+++ b/packages/protoc-gen-pothos/tsconfig.json
@@ -2,5 +2,5 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@proto-graphql/tsconfig/tsconfig.pkg.json",
   "include": ["./src"],
-  "exclude": ["src/__tests__"]
+  "exclude": ["src/__tests__", "src/**/*.mjs"]
 }

--- a/packages/protoc-gen-pothos/tsup.config.ts
+++ b/packages/protoc-gen-pothos/tsup.config.ts
@@ -1,0 +1,32 @@
+import { copyFile } from "node:fs/promises";
+import { defineConfig } from "tsup";
+
+// biome-ignore lint/style/noDefaultExport: allow on external tools configs
+export default defineConfig({
+  entry: [
+    "src/index.ts",
+    "src/protoc-gen-pothos.ts",
+    "src/protoc-gen-nexus.ts",
+    "!src/__tests__/**",
+    "!src/**/*.test.*",
+  ],
+  format: ["cjs", "esm"],
+  sourcemap: true,
+  splitting: false,
+  clean: true,
+  outDir: "dist",
+  onSuccess: async () => {
+    // tsc emits .d.ts only, so the `.mjs` worker isn't bundled by tsup either.
+    // Copy it next to the entry so the runtime resolver finds it.
+    await copyFile(
+      "src/codegen/stringify-worker.mjs",
+      "dist/codegen/stringify-worker.mjs",
+    );
+    const { spawnSync } = await import("node:child_process");
+    const r = spawnSync("tsc", ["-p", ".", "--outDir", "dist"], {
+      stdio: "inherit",
+      shell: true,
+    });
+    if (r.status !== 0) process.exit(r.status ?? 1);
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ catalogs:
     change-case:
       specifier: ^4.1.2
       version: 4.1.2
-    dprint-node:
-      specifier: ^1.0.8
-      version: 1.0.8
   protobuf-es-v1:
     '@bufbuild/protobuf':
       specifier: 1.8.0
@@ -217,9 +214,12 @@ importers:
       '@proto-graphql/protoc-plugin-helpers':
         specifier: workspace:*
         version: link:../@proto-graphql/protoc-plugin-helpers
-      dprint-node:
-        specifier: 'catalog:'
-        version: 1.0.8
+      oxfmt:
+        specifier: ^0.51.0
+        version: 0.51.0
+      synckit:
+        specifier: ^0.11.12
+        version: 0.11.12
     devDependencies:
       '@pothos/core':
         specifier: catalog:test
@@ -2130,9 +2130,135 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxfmt/binding-android-arm-eabi@0.51.0':
+    resolution: {integrity: sha512-Ni0sCqg5CIHaLIYFGj+ncbcumylvNC6FE4rfD0KfdmnWHbPJ+zev0qZCXKxy2hFVa0fYRK0yPzf5nzPbkZou7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.51.0':
+    resolution: {integrity: sha512-eu5lAZjuo0KAkp+M24EhDqfOwA8owQ8d7wyBlOUUGRbDLHpU3IRlDHp8Dif+YqGlxs6jra7yS6WQu/NkPhAxeg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.51.0':
+    resolution: {integrity: sha512-6LsUNIdURhhcIfIn8+xsOb61mSTa9msAHTeSGx9Jf4rsP/gN8PGCF+SKWPAQZbND2w/WBkqQ6303jqEEIXzMdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.51.0':
+    resolution: {integrity: sha512-9aUMGmVxdHjYMsEAW1tNRoieTJXlVNDFkRvIR1J7LttJXWjVYCu2ekclLij2KJtxBxSQOYSHd12ME/adVGVbZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.51.0':
+    resolution: {integrity: sha512-mkY1nhZTqYb+NHaAWxOCKISN6FwdrwMNsu17vTUA3wzUV2VJ+Paq15ZokRcsMU/2PUdHO73prxyeJpjXQ3MPpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.51.0':
+    resolution: {integrity: sha512-wtFwNwE4+YCNuPaWoGDZeGsKvD6D1YSUNBJNn/rJBh7CrDBThFE+TBI5kY7vRW9rIOQRsbW2IpyyL3Du4Zqwiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.51.0':
+    resolution: {integrity: sha512-rnOaNx86G7iRKM6lsCIQMux0SMGNC/TEbFR+r7lpruJ12bnrIWgxd5w1PLqOvgR9r8ZJbpK/zfRKctJnh8/Jfg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.51.0':
+    resolution: {integrity: sha512-jOgDzSqWcICGRjsp4mc08FxKMN8vzP2Kgs4E0d2HUP99F+nJDQKklRV4Zuj+0gcBgjrzx2CbpqaIdUVPepCojA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.51.0':
+    resolution: {integrity: sha512-KBUCdrH5bwVrAvI9gU/1S55oH6fzXjr++J/oVocdu7bYTks1l7DNNT+rLd/1TDdAEjObGwmfWamn7LC1m8A0DQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.51.0':
+    resolution: {integrity: sha512-NapfjYsABFqTJ1Dn9Efq6sN5esaHconVKwVLbDGNQLrwpOx/g17mkwErHzU72PutL67nf3wNAkbq122H+zLxag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.51.0':
+    resolution: {integrity: sha512-5dlDt1dUZCVi6elIhiK1PWg9wpTzTcIuj0IZnSurvIoMrhOWqqTcc1dSTxcSkNaBZhfsNqRZdINI1zAgbKkJNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.51.0':
+    resolution: {integrity: sha512-pgdWUJn0S5nulyiVdlFV8DzCUnGXkU99W5PSkkmbaZW+LrZBPxpezun4G0DDHbQaVYuJeCuKsXsGKGo77CkUTQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.51.0':
+    resolution: {integrity: sha512-2XTFUe97CbDGAI8vjwDfZ1HdakO0XIADyJ24idEg64SC4/K4in/OisXVnrW4NMK7I6TgC7EqRhC0Ln/nKhAemA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.51.0':
+    resolution: {integrity: sha512-kQ1OuCqqt/yyf0ZN9VFxW1/JnlgJgii3Dr7pWf9vNBvrX1hv6g39/+mc5oGRHRGJFZtl3zsGDWR9c5N2B/gwBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.51.0':
+    resolution: {integrity: sha512-ARTYqxHF475o96Gbn41hvSWSSRygPlRDXZZgZ9I2scU1y0qiWpCQyZCoefaQa0mwv+wwtZ+luS4YOzsRzM/izg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.51.0':
+    resolution: {integrity: sha512-QiC1XrCl6a6BmqMzduO8hdIRMf1m44hCkt2Q68KWkTvUB/E7fd2iomyNh6KnnRca5w6eBrRAAtLFqTh+xjsjJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.51.0':
+    resolution: {integrity: sha512-NC/hJb9dtU23Zf8L7IVK95xnFjiQ7AfcLO2l5pb69TDEr958qxrtnB2CveeeNSCBFNIkgaTCfd/vHNSoG78l9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.51.0':
+    resolution: {integrity: sha512-2C45za4Rj36n8YIbhRL1PQbxmXJYf81WEcAgvj5I4ptRROG+A+81hREEN5bmCHADE1UfYaN312U6tkILoZZy6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.51.0':
+    resolution: {integrity: sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@pothos/core@3.41.1':
     resolution: {integrity: sha512-K+TGTK2Q7rmLU9WaC1cSDiGZaU9M+gHNbCYBom2W1vHuEYDUAiihVHz9tXYsrYjFMJSK+wLJ7Xp2374bQa9x/w==}
@@ -3869,6 +3995,16 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
+  oxfmt@0.51.0:
+    resolution: {integrity: sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -4296,6 +4432,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  synckit@0.11.12:
+    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
@@ -4327,6 +4467,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
@@ -5424,8 +5568,67 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  '@oxfmt/binding-android-arm-eabi@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.51.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.51.0':
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@pkgr/core@0.2.9': {}
 
   '@pothos/core@3.41.1(graphql@16.9.0)':
     dependencies:
@@ -7620,6 +7823,30 @@ snapshots:
 
   outdent@0.5.0: {}
 
+  oxfmt@0.51.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.51.0
+      '@oxfmt/binding-android-arm64': 0.51.0
+      '@oxfmt/binding-darwin-arm64': 0.51.0
+      '@oxfmt/binding-darwin-x64': 0.51.0
+      '@oxfmt/binding-freebsd-x64': 0.51.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.51.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.51.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.51.0
+      '@oxfmt/binding-linux-arm64-musl': 0.51.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.51.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.51.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.51.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.51.0
+      '@oxfmt/binding-linux-x64-gnu': 0.51.0
+      '@oxfmt/binding-linux-x64-musl': 0.51.0
+      '@oxfmt/binding-openharmony-arm64': 0.51.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.51.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.51.0
+      '@oxfmt/binding-win32-x64-msvc': 0.51.0
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -8170,6 +8397,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
+
   system-architecture@0.1.0: {}
 
   tabbable@6.4.0: {}
@@ -8194,6 +8425,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.0.3: {}
 

--- a/tests/golden/protobuf-es-v1/testapis.basic.enums/__expected__/testapis/basic/enums/enums.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.basic.enums/__expected__/testapis/basic/enums/enums.pb.pothos.ts
@@ -10,9 +10,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es/lib/testapis/basic/enums/enums_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const MessageWithEnums$Ref = builder.objectRef<MessageWithEnums>(
-  "MessageWithEnums",
-);
+export const MessageWithEnums$Ref =
+  builder.objectRef<MessageWithEnums>("MessageWithEnums");
 builder.objectType(MessageWithEnums$Ref, {
   name: "MessageWithEnums",
   fields: (t) => ({
@@ -170,122 +169,120 @@ builder.objectType(MessageWithEnums$Ref, {
 export type MessageWithEnumsInput$Shape = {
   requiredMyEnum: MessageWithEnums["requiredMyEnum"];
   optionalMyEnum?: MessageWithEnums["optionalMyEnum"] | null;
-  requiredMyEnumWithoutUnspecified:
-    MessageWithEnums["requiredMyEnumWithoutUnspecified"];
+  requiredMyEnumWithoutUnspecified: MessageWithEnums["requiredMyEnumWithoutUnspecified"];
   optionalMyEnumWithoutUnspecified?:
     | MessageWithEnums["optionalMyEnumWithoutUnspecified"]
     | null;
   requiredMyEnums: MessageWithEnums["requiredMyEnums"];
   optionalMyEnums?: MessageWithEnums["optionalMyEnums"] | null;
-  requiredMyEnumWithoutUnspecifieds:
-    MessageWithEnums["requiredMyEnumWithoutUnspecifieds"];
+  requiredMyEnumWithoutUnspecifieds: MessageWithEnums["requiredMyEnumWithoutUnspecifieds"];
   optionalMyEnumWithoutUnspecifieds?:
     | MessageWithEnums["optionalMyEnumWithoutUnspecifieds"]
     | null;
 };
 
-export const MessageWithEnumsInput$Ref: InputObjectRef<
-  MessageWithEnumsInput$Shape
-> = builder.inputRef<MessageWithEnumsInput$Shape>("MessageWithEnumsInput")
-  .implement({
-    fields: (t) => ({
-      requiredMyEnum: t.field({
-        type: MyEnum$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enum",
-            typeFullName: "testapis.basic.enums.MyEnum",
+export const MessageWithEnumsInput$Ref: InputObjectRef<MessageWithEnumsInput$Shape> =
+  builder
+    .inputRef<MessageWithEnumsInput$Shape>("MessageWithEnumsInput")
+    .implement({
+      fields: (t) => ({
+        requiredMyEnum: t.field({
+          type: MyEnum$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enum",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      optionalMyEnum: t.field({
-        type: MyEnum$Ref,
-        required: false,
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enum",
-            typeFullName: "testapis.basic.enums.MyEnum",
+        }),
+        optionalMyEnum: t.field({
+          type: MyEnum$Ref,
+          required: false,
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enum",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      requiredMyEnumWithoutUnspecified: t.field({
-        type: MyEnumWithoutUnspecified$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enum_without_unspecified",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        requiredMyEnumWithoutUnspecified: t.field({
+          type: MyEnumWithoutUnspecified$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enum_without_unspecified",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
-      }),
-      optionalMyEnumWithoutUnspecified: t.field({
-        type: MyEnumWithoutUnspecified$Ref,
-        required: false,
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enum_without_unspecified",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        optionalMyEnumWithoutUnspecified: t.field({
+          type: MyEnumWithoutUnspecified$Ref,
+          required: false,
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enum_without_unspecified",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
-      }),
-      requiredMyEnums: t.field({
-        type: [MyEnum$Ref],
-        required: { list: true, items: true },
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enums",
-            typeFullName: "testapis.basic.enums.MyEnum",
+        }),
+        requiredMyEnums: t.field({
+          type: [MyEnum$Ref],
+          required: { list: true, items: true },
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enums",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      optionalMyEnums: t.field({
-        type: [MyEnum$Ref],
-        required: { list: false, items: true },
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enums",
-            typeFullName: "testapis.basic.enums.MyEnum",
+        }),
+        optionalMyEnums: t.field({
+          type: [MyEnum$Ref],
+          required: { list: false, items: true },
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enums",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      requiredMyEnumWithoutUnspecifieds: t.field({
-        type: [MyEnumWithoutUnspecified$Ref],
-        required: { list: true, items: true },
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enum_without_unspecifieds",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        requiredMyEnumWithoutUnspecifieds: t.field({
+          type: [MyEnumWithoutUnspecified$Ref],
+          required: { list: true, items: true },
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enum_without_unspecifieds",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
-      }),
-      optionalMyEnumWithoutUnspecifieds: t.field({
-        type: [MyEnumWithoutUnspecified$Ref],
-        required: { list: false, items: true },
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enum_without_unspecifieds",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        optionalMyEnumWithoutUnspecifieds: t.field({
+          type: [MyEnumWithoutUnspecified$Ref],
+          required: { list: false, items: true },
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enum_without_unspecifieds",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.enums.MessageWithEnums",
-        name: "MessageWithEnums",
-        package: "testapis.basic.enums",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.enums.MessageWithEnums",
+          name: "MessageWithEnums",
+          package: "testapis.basic.enums",
+        },
       },
-    },
-  });
+    });
 
 export function MessageWithEnumsInput$toProto(
   input: MessageWithEnumsInput$Shape | null | undefined,
@@ -293,10 +290,10 @@ export function MessageWithEnumsInput$toProto(
   return new MessageWithEnums({
     requiredMyEnum: input?.requiredMyEnum ?? undefined,
     optionalMyEnum: input?.optionalMyEnum ?? undefined,
-    requiredMyEnumWithoutUnspecified: input?.requiredMyEnumWithoutUnspecified ??
-      undefined,
-    optionalMyEnumWithoutUnspecified: input?.optionalMyEnumWithoutUnspecified ??
-      undefined,
+    requiredMyEnumWithoutUnspecified:
+      input?.requiredMyEnumWithoutUnspecified ?? undefined,
+    optionalMyEnumWithoutUnspecified:
+      input?.optionalMyEnumWithoutUnspecified ?? undefined,
     requiredMyEnums: input?.requiredMyEnums ?? undefined,
     optionalMyEnums: input?.optionalMyEnums ?? undefined,
     requiredMyEnumWithoutUnspecifieds:

--- a/tests/golden/protobuf-es-v1/testapis.basic.nested/__expected__/testapis/basic/nested/nested.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.basic.nested/__expected__/testapis/basic/nested/nested.pb.pothos.ts
@@ -10,9 +10,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es/lib/testapis/basic/nested/nested_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const ParentMessage$Ref = builder.objectRef<ParentMessage>(
-  "ParentMessage",
-);
+export const ParentMessage$Ref =
+  builder.objectRef<ParentMessage>("ParentMessage");
 builder.objectType(ParentMessage$Ref, {
   name: "ParentMessage",
   fields: (t) => ({
@@ -63,9 +62,8 @@ builder.objectType(ParentMessage$Ref, {
   },
 });
 
-export const ParentMessageNestedMessage$Ref = builder.objectRef<
-  ParentMessage_NestedMessage
->("ParentMessageNestedMessage");
+export const ParentMessageNestedMessage$Ref =
+  builder.objectRef<ParentMessage_NestedMessage>("ParentMessageNestedMessage");
 builder.objectType(ParentMessageNestedMessage$Ref, {
   name: "ParentMessageNestedMessage",
   fields: (t) => ({
@@ -96,42 +94,46 @@ export type ParentMessageInput$Shape = {
 };
 
 export const ParentMessageInput$Ref: InputObjectRef<ParentMessageInput$Shape> =
-  builder.inputRef<ParentMessageInput$Shape>("ParentMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      nested: t.field({
-        type: ParentMessageNestedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "nested",
-            typeFullName: "testapis.basic.nested.ParentMessage.NestedMessage",
+  builder
+    .inputRef<ParentMessageInput$Shape>("ParentMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
-      }),
-      nestedEnum: t.field({
-        type: ParentMessageNestedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "nested_enum",
-            typeFullName: "testapis.basic.nested.ParentMessage.NestedEnum",
+        }),
+        nested: t.field({
+          type: ParentMessageNestedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "nested",
+              typeFullName: "testapis.basic.nested.ParentMessage.NestedMessage",
+            },
           },
-        },
+        }),
+        nestedEnum: t.field({
+          type: ParentMessageNestedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "nested_enum",
+              typeFullName: "testapis.basic.nested.ParentMessage.NestedEnum",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.nested.ParentMessage",
-        name: "ParentMessage",
-        package: "testapis.basic.nested",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.nested.ParentMessage",
+          name: "ParentMessage",
+          package: "testapis.basic.nested",
+        },
       },
-    },
-  });
+    });
 
 export function ParentMessageInput$toProto(
   input: ParentMessageInput$Shape | null | undefined,
@@ -149,28 +151,29 @@ export type ParentMessageNestedMessageInput$Shape = {
   nestedBody: ParentMessage_NestedMessage["nestedBody"];
 };
 
-export const ParentMessageNestedMessageInput$Ref: InputObjectRef<
-  ParentMessageNestedMessageInput$Shape
-> = builder.inputRef<ParentMessageNestedMessageInput$Shape>(
-  "ParentMessageNestedMessageInput",
-).implement({
-  fields: (t) => ({
-    nestedBody: t.field({
-      type: "String",
-      required: true,
+export const ParentMessageNestedMessageInput$Ref: InputObjectRef<ParentMessageNestedMessageInput$Shape> =
+  builder
+    .inputRef<ParentMessageNestedMessageInput$Shape>(
+      "ParentMessageNestedMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        nestedBody: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "nested_body", typeFullName: "string" },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: { name: "nested_body", typeFullName: "string" },
+        protobufMessage: {
+          fullName: "testapis.basic.nested.ParentMessage.NestedMessage",
+          name: "NestedMessage",
+          package: "testapis.basic.nested",
+        },
       },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.basic.nested.ParentMessage.NestedMessage",
-      name: "NestedMessage",
-      package: "testapis.basic.nested",
-    },
-  },
-});
+    });
 
 export function ParentMessageNestedMessageInput$toProto(
   input: ParentMessageNestedMessageInput$Shape | null | undefined,

--- a/tests/golden/protobuf-es-v1/testapis.basic.presence/__expected__/testapis/basic/presence/presence.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.basic.presence/__expected__/testapis/basic/presence/presence.pb.pothos.ts
@@ -56,9 +56,8 @@ builder.objectType(Message$Ref, {
   },
 });
 
-export const NestedMessage$Ref = builder.objectRef<NestedMessage>(
-  "NestedMessage",
-);
+export const NestedMessage$Ref =
+  builder.objectRef<NestedMessage>("NestedMessage");
 builder.objectType(NestedMessage$Ref, {
   name: "NestedMessage",
   fields: (t) => ({
@@ -87,7 +86,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredStringValue: t.field({
         type: "String",
@@ -141,28 +141,36 @@ export function MessageInput$toProto(
   });
 }
 
-export type NestedMessageInput$Shape = { body: NestedMessage["body"]; };
+export type NestedMessageInput$Shape = {
+  body: NestedMessage["body"];
+};
 
 export const NestedMessageInput$Ref: InputObjectRef<NestedMessageInput$Shape> =
-  builder.inputRef<NestedMessageInput$Shape>("NestedMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<NestedMessageInput$Shape>("NestedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.presence.NestedMessage",
-        name: "NestedMessage",
-        package: "testapis.basic.presence",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.presence.NestedMessage",
+          name: "NestedMessage",
+          package: "testapis.basic.presence",
+        },
       },
-    },
-  });
+    });
 
 export function NestedMessageInput$toProto(
   input: NestedMessageInput$Shape | null | undefined,
 ): NestedMessage {
-  return new NestedMessage({ body: input?.body ?? undefined });
+  return new NestedMessage({
+    body: input?.body ?? undefined,
+  });
 }

--- a/tests/golden/protobuf-es-v1/testapis.basic.scalars/__expected__/testapis/basic/scalars/scalars.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.basic.scalars/__expected__/testapis/basic/scalars/scalars.pb.pothos.ts
@@ -377,7 +377,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredPrimitives: t.field({
         type: PrimitivesInput$Ref,
@@ -444,10 +445,10 @@ export function MessageInput$toProto(
       ? PrimitivesInput$toProto(input.optionalPrimitives)
       : undefined,
     requiredPrimitivesList: input?.requiredPrimitivesList?.map((v) =>
-      PrimitivesInput$toProto(v)
+      PrimitivesInput$toProto(v),
     ),
     optionalPrimitivesList: input?.optionalPrimitivesList?.map((v) =>
-      PrimitivesInput$toProto(v)
+      PrimitivesInput$toProto(v),
     ),
   });
 }
@@ -486,311 +487,319 @@ export type PrimitivesInput$Shape = {
 };
 
 export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
-  builder.inputRef<PrimitivesInput$Shape>("PrimitivesInput").implement({
-    fields: (t) => ({
-      requiredDoubleValue: t.field({
-        type: "Float",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_double_value",
-            typeFullName: "double",
+  builder
+    .inputRef<PrimitivesInput$Shape>("PrimitivesInput")
+    .implement({
+      fields: (t) => ({
+        requiredDoubleValue: t.field({
+          type: "Float",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_double_value",
+              typeFullName: "double",
+            },
           },
-        },
-      }),
-      requiredFloatValue: t.field({
-        type: "Float",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_float_value",
-            typeFullName: "float",
+        }),
+        requiredFloatValue: t.field({
+          type: "Float",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_float_value",
+              typeFullName: "float",
+            },
           },
-        },
-      }),
-      requiredInt32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_int32_value",
-            typeFullName: "int32",
+        }),
+        requiredInt32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_int32_value",
+              typeFullName: "int32",
+            },
           },
-        },
-      }),
-      requiredInt64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_int64_value",
-            typeFullName: "int64",
+        }),
+        requiredInt64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_int64_value",
+              typeFullName: "int64",
+            },
           },
-        },
-      }),
-      requiredUint32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_uint32_value",
-            typeFullName: "uint32",
+        }),
+        requiredUint32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_uint32_value",
+              typeFullName: "uint32",
+            },
           },
-        },
-      }),
-      requiredUint64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_uint64_value",
-            typeFullName: "uint64",
+        }),
+        requiredUint64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_uint64_value",
+              typeFullName: "uint64",
+            },
           },
-        },
-      }),
-      requiredSint32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sint32_value",
-            typeFullName: "sint32",
+        }),
+        requiredSint32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sint32_value",
+              typeFullName: "sint32",
+            },
           },
-        },
-      }),
-      requiredSint64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sint64_value",
-            typeFullName: "sint64",
+        }),
+        requiredSint64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sint64_value",
+              typeFullName: "sint64",
+            },
           },
-        },
-      }),
-      requiredFixed32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_fixed32_value",
-            typeFullName: "fixed32",
+        }),
+        requiredFixed32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_fixed32_value",
+              typeFullName: "fixed32",
+            },
           },
-        },
-      }),
-      requiredFixed64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_fixed64_value",
-            typeFullName: "fixed64",
+        }),
+        requiredFixed64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_fixed64_value",
+              typeFullName: "fixed64",
+            },
           },
-        },
-      }),
-      requiredSfixed32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sfixed32_value",
-            typeFullName: "sfixed32",
+        }),
+        requiredSfixed32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sfixed32_value",
+              typeFullName: "sfixed32",
+            },
           },
-        },
-      }),
-      requiredSfixed64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sfixed64_value",
-            typeFullName: "sfixed64",
+        }),
+        requiredSfixed64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sfixed64_value",
+              typeFullName: "sfixed64",
+            },
           },
-        },
-      }),
-      requiredBoolValue: t.field({
-        type: "Boolean",
-        required: true,
-        extensions: {
-          protobufField: { name: "required_bool_value", typeFullName: "bool" },
-        },
-      }),
-      requiredStringValue: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_string_value",
-            typeFullName: "string",
+        }),
+        requiredBoolValue: t.field({
+          type: "Boolean",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_bool_value",
+              typeFullName: "bool",
+            },
           },
-        },
-      }),
-      requiredBytesValue: t.field({
-        type: "Byte",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_bytes_value",
-            typeFullName: "bytes",
+        }),
+        requiredStringValue: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_string_value",
+              typeFullName: "string",
+            },
           },
-        },
-      }),
-      requiredDoubleValues: t.field({
-        type: ["Float"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_double_values",
-            typeFullName: "double",
+        }),
+        requiredBytesValue: t.field({
+          type: "Byte",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_bytes_value",
+              typeFullName: "bytes",
+            },
           },
-        },
-      }),
-      requiredFloatValues: t.field({
-        type: ["Float"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_float_values",
-            typeFullName: "float",
+        }),
+        requiredDoubleValues: t.field({
+          type: ["Float"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_double_values",
+              typeFullName: "double",
+            },
           },
-        },
-      }),
-      requiredInt32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_int32_values",
-            typeFullName: "int32",
+        }),
+        requiredFloatValues: t.field({
+          type: ["Float"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_float_values",
+              typeFullName: "float",
+            },
           },
-        },
-      }),
-      requiredInt64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_int64_values",
-            typeFullName: "int64",
+        }),
+        requiredInt32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_int32_values",
+              typeFullName: "int32",
+            },
           },
-        },
-      }),
-      requiredUint32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_uint32_values",
-            typeFullName: "uint32",
+        }),
+        requiredInt64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_int64_values",
+              typeFullName: "int64",
+            },
           },
-        },
-      }),
-      requiredUint64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_uint64_values",
-            typeFullName: "uint64",
+        }),
+        requiredUint32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_uint32_values",
+              typeFullName: "uint32",
+            },
           },
-        },
-      }),
-      requiredSint32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sint32_values",
-            typeFullName: "sint32",
+        }),
+        requiredUint64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_uint64_values",
+              typeFullName: "uint64",
+            },
           },
-        },
-      }),
-      requiredSint64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sint64_values",
-            typeFullName: "sint64",
+        }),
+        requiredSint32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sint32_values",
+              typeFullName: "sint32",
+            },
           },
-        },
-      }),
-      requiredFixed32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_fixed32_values",
-            typeFullName: "fixed32",
+        }),
+        requiredSint64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sint64_values",
+              typeFullName: "sint64",
+            },
           },
-        },
-      }),
-      requiredFixed64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_fixed64_values",
-            typeFullName: "fixed64",
+        }),
+        requiredFixed32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_fixed32_values",
+              typeFullName: "fixed32",
+            },
           },
-        },
-      }),
-      requiredSfixed32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sfixed32_values",
-            typeFullName: "sfixed32",
+        }),
+        requiredFixed64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_fixed64_values",
+              typeFullName: "fixed64",
+            },
           },
-        },
-      }),
-      requiredSfixed64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sfixed64_values",
-            typeFullName: "sfixed64",
+        }),
+        requiredSfixed32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sfixed32_values",
+              typeFullName: "sfixed32",
+            },
           },
-        },
-      }),
-      requiredBoolValues: t.field({
-        type: ["Boolean"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: { name: "required_bool_values", typeFullName: "bool" },
-        },
-      }),
-      requiredStringValues: t.field({
-        type: ["String"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_string_values",
-            typeFullName: "string",
+        }),
+        requiredSfixed64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sfixed64_values",
+              typeFullName: "sfixed64",
+            },
           },
-        },
-      }),
-      requiredBytesValues: t.field({
-        type: ["Byte"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_bytes_values",
-            typeFullName: "bytes",
+        }),
+        requiredBoolValues: t.field({
+          type: ["Boolean"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_bool_values",
+              typeFullName: "bool",
+            },
           },
-        },
+        }),
+        requiredStringValues: t.field({
+          type: ["String"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_string_values",
+              typeFullName: "string",
+            },
+          },
+        }),
+        requiredBytesValues: t.field({
+          type: ["Byte"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_bytes_values",
+              typeFullName: "bytes",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.scalars.Primitives",
-        name: "Primitives",
-        package: "testapis.basic.scalars",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.scalars.Primitives",
+          name: "Primitives",
+          package: "testapis.basic.scalars",
+        },
       },
-    },
-  });
+    });
 
 export function PrimitivesInput$toProto(
   input: PrimitivesInput$Shape | null | undefined,

--- a/tests/golden/protobuf-es-v1/testapis.basic.wktypes/__expected__/testapis/basic/wktypes/wktypes.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.basic.wktypes/__expected__/testapis/basic/wktypes/wktypes.pb.pothos.ts
@@ -157,7 +157,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       timestamp: t.field({
         type: "DateTime",

--- a/tests/golden/protobuf-es-v1/testapis.behavior.field_comments/__expected__/testapis/behavior/field_comments/field_comments.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.behavior.field_comments/__expected__/testapis/behavior/field_comments/field_comments.pb.pothos.ts
@@ -9,9 +9,10 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es/lib/testapis/behavior/field_comments/field_comments_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const FieldBehaviorCommentsMessage$Ref = builder.objectRef<
-  FieldBehaviorCommentsMessage
->("FieldBehaviorCommentsMessage");
+export const FieldBehaviorCommentsMessage$Ref =
+  builder.objectRef<FieldBehaviorCommentsMessage>(
+    "FieldBehaviorCommentsMessage",
+  );
 builder.objectType(FieldBehaviorCommentsMessage$Ref, {
   name: "FieldBehaviorCommentsMessage",
   fields: (t) => ({
@@ -85,9 +86,10 @@ builder.objectType(FieldBehaviorCommentsMessage$Ref, {
   },
 });
 
-export const FieldBehaviorCommentsMessagePost$Ref = builder.objectRef<
-  FieldBehaviorCommentsMessage_Post
->("FieldBehaviorCommentsMessagePost");
+export const FieldBehaviorCommentsMessagePost$Ref =
+  builder.objectRef<FieldBehaviorCommentsMessage_Post>(
+    "FieldBehaviorCommentsMessagePost",
+  );
 builder.objectType(FieldBehaviorCommentsMessagePost$Ref, {
   name: "FieldBehaviorCommentsMessagePost",
   fields: (t) => ({
@@ -117,69 +119,71 @@ export type FieldBehaviorCommentsMessageInput$Shape = {
   inputOnlyField?: FieldBehaviorCommentsMessagePostInput$Shape | null;
 };
 
-export const FieldBehaviorCommentsMessageInput$Ref: InputObjectRef<
-  FieldBehaviorCommentsMessageInput$Shape
-> = builder.inputRef<FieldBehaviorCommentsMessageInput$Shape>(
-  "FieldBehaviorCommentsMessageInput",
-).implement({
-  fields: (t) => ({
-    requiredField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: true,
-      description: "Required.",
+export const FieldBehaviorCommentsMessageInput$Ref: InputObjectRef<FieldBehaviorCommentsMessageInput$Shape> =
+  builder
+    .inputRef<FieldBehaviorCommentsMessageInput$Shape>(
+      "FieldBehaviorCommentsMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        requiredField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+        requiredInputOnlyField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: true,
+          description: "Required. Input only.",
+          extensions: {
+            protobufField: {
+              name: "required_input_only_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+        inputOnlyRequiredField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: true,
+          description: "Input only. Required.",
+          extensions: {
+            protobufField: {
+              name: "input_only_required_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+        inputOnlyField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: false,
+          description: "Input only.",
+          extensions: {
+            protobufField: {
+              name: "input_only_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "required_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+        protobufMessage: {
+          fullName:
+            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage",
+          name: "FieldBehaviorCommentsMessage",
+          package: "testapis.behavior.field_comments",
         },
       },
-    }),
-    requiredInputOnlyField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: true,
-      description: "Required. Input only.",
-      extensions: {
-        protobufField: {
-          name: "required_input_only_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-        },
-      },
-    }),
-    inputOnlyRequiredField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: true,
-      description: "Input only. Required.",
-      extensions: {
-        protobufField: {
-          name: "input_only_required_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-        },
-      },
-    }),
-    inputOnlyField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: false,
-      description: "Input only.",
-      extensions: {
-        protobufField: {
-          name: "input_only_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.behavior.field_comments.FieldBehaviorCommentsMessage",
-      name: "FieldBehaviorCommentsMessage",
-      package: "testapis.behavior.field_comments",
-    },
-  },
-});
+    });
 
 export function FieldBehaviorCommentsMessageInput$toProto(
   input: FieldBehaviorCommentsMessageInput$Shape | null | undefined,
@@ -190,13 +194,13 @@ export function FieldBehaviorCommentsMessageInput$toProto(
       : undefined,
     requiredInputOnlyField: input?.requiredInputOnlyField
       ? FieldBehaviorCommentsMessagePostInput$toProto(
-        input.requiredInputOnlyField,
-      )
+          input.requiredInputOnlyField,
+        )
       : undefined,
     inputOnlyRequiredField: input?.inputOnlyRequiredField
       ? FieldBehaviorCommentsMessagePostInput$toProto(
-        input.inputOnlyRequiredField,
-      )
+          input.inputOnlyRequiredField,
+        )
       : undefined,
     inputOnlyField: input?.inputOnlyField
       ? FieldBehaviorCommentsMessagePostInput$toProto(input.inputOnlyField)
@@ -208,27 +212,30 @@ export type FieldBehaviorCommentsMessagePostInput$Shape = {
   body: FieldBehaviorCommentsMessage_Post["body"];
 };
 
-export const FieldBehaviorCommentsMessagePostInput$Ref: InputObjectRef<
-  FieldBehaviorCommentsMessagePostInput$Shape
-> = builder.inputRef<FieldBehaviorCommentsMessagePostInput$Shape>(
-  "FieldBehaviorCommentsMessagePostInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-      name: "Post",
-      package: "testapis.behavior.field_comments",
-    },
-  },
-});
+export const FieldBehaviorCommentsMessagePostInput$Ref: InputObjectRef<FieldBehaviorCommentsMessagePostInput$Shape> =
+  builder
+    .inputRef<FieldBehaviorCommentsMessagePostInput$Shape>(
+      "FieldBehaviorCommentsMessagePostInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+          name: "Post",
+          package: "testapis.behavior.field_comments",
+        },
+      },
+    });
 
 export function FieldBehaviorCommentsMessagePostInput$toProto(
   input: FieldBehaviorCommentsMessagePostInput$Shape | null | undefined,

--- a/tests/golden/protobuf-es-v1/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_a/types.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_a/types.pb.pothos.ts
@@ -79,36 +79,45 @@ builder.objectType(ParentChild$Ref, {
   },
 });
 
-export type BaseMessageInput$Shape = { body: BaseMessage["body"]; };
+export type BaseMessageInput$Shape = {
+  body: BaseMessage["body"];
+};
 
 export const BaseMessageInput$Ref: InputObjectRef<BaseMessageInput$Shape> =
-  builder.inputRef<BaseMessageInput$Shape>("BaseMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<BaseMessageInput$Shape>("BaseMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.cross_pkg_a.BaseMessage",
-        name: "BaseMessage",
-        package: "testapis.imports.cross_pkg_a",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.cross_pkg_a.BaseMessage",
+          name: "BaseMessage",
+          package: "testapis.imports.cross_pkg_a",
+        },
       },
-    },
-  });
+    });
 
 export function BaseMessageInput$toProto(
   input: BaseMessageInput$Shape | null | undefined,
 ): BaseMessage {
-  return new BaseMessage({ body: input?.body ?? undefined });
+  return new BaseMessage({
+    body: input?.body ?? undefined,
+  });
 }
 
 export type ParentInput$Shape = {};
 
 export const ParentInput$Ref: InputObjectRef<ParentInput$Shape> = builder
-  .inputRef<ParentInput$Shape>("ParentInput").implement({
+  .inputRef<ParentInput$Shape>("ParentInput")
+  .implement({
     fields: (t) => ({
       _: t.field({
         type: "Boolean",
@@ -131,30 +140,38 @@ export function ParentInput$toProto(
   return new Parent({});
 }
 
-export type ParentChildInput$Shape = { body: Parent_Child["body"]; };
+export type ParentChildInput$Shape = {
+  body: Parent_Child["body"];
+};
 
 export const ParentChildInput$Ref: InputObjectRef<ParentChildInput$Shape> =
-  builder.inputRef<ParentChildInput$Shape>("ParentChildInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<ParentChildInput$Shape>("ParentChildInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.cross_pkg_a.Parent.Child",
-        name: "Child",
-        package: "testapis.imports.cross_pkg_a",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.cross_pkg_a.Parent.Child",
+          name: "Child",
+          package: "testapis.imports.cross_pkg_a",
+        },
       },
-    },
-  });
+    });
 
 export function ParentChildInput$toProto(
   input: ParentChildInput$Shape | null | undefined,
 ): Parent_Child {
-  return new Parent_Child({ body: input?.body ?? undefined });
+  return new Parent_Child({
+    body: input?.body ?? undefined,
+  });
 }
 
 export const BaseEnum$Ref: EnumRef<BaseEnum, BaseEnum> = builder.enumType(

--- a/tests/golden/protobuf-es-v1/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_b/consumer.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_b/consumer.pb.pothos.ts
@@ -101,7 +101,8 @@ export type ConsumerInput$Shape = {
 };
 
 export const ConsumerInput$Ref: InputObjectRef<ConsumerInput$Shape> = builder
-  .inputRef<ConsumerInput$Shape>("ConsumerInput").implement({
+  .inputRef<ConsumerInput$Shape>("ConsumerInput")
+  .implement({
     fields: (t) => ({
       message: t.field({
         type: BaseMessageInput$Ref,

--- a/tests/golden/protobuf-es-v1/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/member.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/member.pb.pothos.ts
@@ -53,54 +53,70 @@ builder.objectType(OneofMember2$Ref, {
   },
 });
 
-export type OneofMember1Input$Shape = { body: OneofMember1["body"]; };
+export type OneofMember1Input$Shape = {
+  body: OneofMember1["body"];
+};
 
 export const OneofMember1Input$Ref: InputObjectRef<OneofMember1Input$Shape> =
-  builder.inputRef<OneofMember1Input$Shape>("OneofMember1Input").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<OneofMember1Input$Shape>("OneofMember1Input")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.oneof_cross_file.OneofMember1",
-        name: "OneofMember1",
-        package: "testapis.imports.oneof_cross_file",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.oneof_cross_file.OneofMember1",
+          name: "OneofMember1",
+          package: "testapis.imports.oneof_cross_file",
+        },
       },
-    },
-  });
+    });
 
 export function OneofMember1Input$toProto(
   input: OneofMember1Input$Shape | null | undefined,
 ): OneofMember1 {
-  return new OneofMember1({ body: input?.body ?? undefined });
+  return new OneofMember1({
+    body: input?.body ?? undefined,
+  });
 }
 
-export type OneofMember2Input$Shape = { count: OneofMember2["count"]; };
+export type OneofMember2Input$Shape = {
+  count: OneofMember2["count"];
+};
 
 export const OneofMember2Input$Ref: InputObjectRef<OneofMember2Input$Shape> =
-  builder.inputRef<OneofMember2Input$Shape>("OneofMember2Input").implement({
-    fields: (t) => ({
-      count: t.field({
-        type: "Int",
-        required: true,
-        extensions: { protobufField: { name: "count", typeFullName: "int32" } },
+  builder
+    .inputRef<OneofMember2Input$Shape>("OneofMember2Input")
+    .implement({
+      fields: (t) => ({
+        count: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: { name: "count", typeFullName: "int32" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.oneof_cross_file.OneofMember2",
-        name: "OneofMember2",
-        package: "testapis.imports.oneof_cross_file",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.oneof_cross_file.OneofMember2",
+          name: "OneofMember2",
+          package: "testapis.imports.oneof_cross_file",
+        },
       },
-    },
-  });
+    });
 
 export function OneofMember2Input$toProto(
   input: OneofMember2Input$Shape | null | undefined,
 ): OneofMember2 {
-  return new OneofMember2({ count: input?.count ?? undefined });
+  return new OneofMember2({
+    count: input?.count ?? undefined,
+  });
 }

--- a/tests/golden/protobuf-es-v1/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/parent.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/parent.pb.pothos.ts
@@ -55,37 +55,39 @@ export type OneofParentInput$Shape = {
 };
 
 export const OneofParentInput$Ref: InputObjectRef<OneofParentInput$Shape> =
-  builder.inputRef<OneofParentInput$Shape>("OneofParentInput").implement({
-    fields: (t) => ({
-      member1: t.field({
-        type: OneofMember1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "member1",
-            typeFullName: "testapis.imports.oneof_cross_file.OneofMember1",
+  builder
+    .inputRef<OneofParentInput$Shape>("OneofParentInput")
+    .implement({
+      fields: (t) => ({
+        member1: t.field({
+          type: OneofMember1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "member1",
+              typeFullName: "testapis.imports.oneof_cross_file.OneofMember1",
+            },
           },
-        },
-      }),
-      member2: t.field({
-        type: OneofMember2Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "member2",
-            typeFullName: "testapis.imports.oneof_cross_file.OneofMember2",
+        }),
+        member2: t.field({
+          type: OneofMember2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "member2",
+              typeFullName: "testapis.imports.oneof_cross_file.OneofMember2",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.oneof_cross_file.OneofParent",
-        name: "OneofParent",
-        package: "testapis.imports.oneof_cross_file",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.oneof_cross_file.OneofParent",
+          name: "OneofParent",
+          package: "testapis.imports.oneof_cross_file",
+        },
       },
-    },
-  });
+    });
 
 export function OneofParentInput$toProto(
   input: OneofParentInput$Shape | null | undefined,
@@ -94,8 +96,8 @@ export function OneofParentInput$toProto(
     oneofField: input?.member1
       ? { case: "member1", value: OneofMember1Input$toProto(input.member1) }
       : input?.member2
-      ? { case: "member2", value: OneofMember2Input$toProto(input.member2) }
-      : undefined,
+        ? { case: "member2", value: OneofMember2Input$toProto(input.member2) }
+        : undefined,
   });
 }
 
@@ -109,13 +111,16 @@ export const OneofParentOneofField$Ref = builder.unionType(
         name: "oneof_field",
         messageName: "OneofParent",
         package: "testapis.imports.oneof_cross_file",
-        fields: [{
-          name: "member1",
-          type: "testapis.imports.oneof_cross_file.OneofMember1",
-        }, {
-          name: "member2",
-          type: "testapis.imports.oneof_cross_file.OneofMember2",
-        }],
+        fields: [
+          {
+            name: "member1",
+            type: "testapis.imports.oneof_cross_file.OneofMember1",
+          },
+          {
+            name: "member2",
+            type: "testapis.imports.oneof_cross_file.OneofMember2",
+          },
+        ],
       },
     },
   },

--- a/tests/golden/protobuf-es-v1/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/base.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/base.pb.pothos.ts
@@ -9,9 +9,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es/lib/testapis/imports/same_dir/base_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const SharedMessage$Ref = builder.objectRef<SharedMessage>(
-  "SharedMessage",
-);
+export const SharedMessage$Ref =
+  builder.objectRef<SharedMessage>("SharedMessage");
 builder.objectType(SharedMessage$Ref, {
   name: "SharedMessage",
   fields: (t) => ({
@@ -33,30 +32,38 @@ builder.objectType(SharedMessage$Ref, {
   },
 });
 
-export type SharedMessageInput$Shape = { body: SharedMessage["body"]; };
+export type SharedMessageInput$Shape = {
+  body: SharedMessage["body"];
+};
 
 export const SharedMessageInput$Ref: InputObjectRef<SharedMessageInput$Shape> =
-  builder.inputRef<SharedMessageInput$Shape>("SharedMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<SharedMessageInput$Shape>("SharedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.same_dir.SharedMessage",
-        name: "SharedMessage",
-        package: "testapis.imports.same_dir",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.same_dir.SharedMessage",
+          name: "SharedMessage",
+          package: "testapis.imports.same_dir",
+        },
       },
-    },
-  });
+    });
 
 export function SharedMessageInput$toProto(
   input: SharedMessageInput$Shape | null | undefined,
 ): SharedMessage {
-  return new SharedMessage({ body: input?.body ?? undefined });
+  return new SharedMessage({
+    body: input?.body ?? undefined,
+  });
 }
 
 export const SharedEnum$Ref: EnumRef<SharedEnum, SharedEnum> = builder.enumType(

--- a/tests/golden/protobuf-es-v1/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/consumer.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/consumer.pb.pothos.ts
@@ -64,7 +64,8 @@ export type ConsumerInput$Shape = {
 };
 
 export const ConsumerInput$Ref: InputObjectRef<ConsumerInput$Shape> = builder
-  .inputRef<ConsumerInput$Shape>("ConsumerInput").implement({
+  .inputRef<ConsumerInput$Shape>("ConsumerInput")
+  .implement({
     fields: (t) => ({
       message: t.field({
         type: SharedMessageInput$Ref,

--- a/tests/golden/protobuf-es-v1/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg1.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg1.pb.pothos.ts
@@ -9,9 +9,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es/lib/testapis/imports/squashed_union/pkg1_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const OneofMessage1$Ref = builder.objectRef<OneofMessage1>(
-  "OneofMessage1",
-);
+export const OneofMessage1$Ref =
+  builder.objectRef<OneofMessage1>("OneofMessage1");
 builder.objectType(OneofMessage1$Ref, {
   name: "OneofMessage1",
   fields: (t) => ({
@@ -33,30 +32,38 @@ builder.objectType(OneofMessage1$Ref, {
   },
 });
 
-export type OneofMessage1Input$Shape = { body: OneofMessage1["body"]; };
+export type OneofMessage1Input$Shape = {
+  body: OneofMessage1["body"];
+};
 
 export const OneofMessage1Input$Ref: InputObjectRef<OneofMessage1Input$Shape> =
-  builder.inputRef<OneofMessage1Input$Shape>("OneofMessage1Input").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<OneofMessage1Input$Shape>("OneofMessage1Input")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.squashed_union.pkg1.OneofMessage1",
-        name: "OneofMessage1",
-        package: "testapis.imports.squashed_union.pkg1",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.squashed_union.pkg1.OneofMessage1",
+          name: "OneofMessage1",
+          package: "testapis.imports.squashed_union.pkg1",
+        },
       },
-    },
-  });
+    });
 
 export function OneofMessage1Input$toProto(
   input: OneofMessage1Input$Shape | null | undefined,
 ): OneofMessage1 {
-  return new OneofMessage1({ body: input?.body ?? undefined });
+  return new OneofMessage1({
+    body: input?.body ?? undefined,
+  });
 }
 
 export type SquashedOneofInput$Shape = {
@@ -64,28 +71,31 @@ export type SquashedOneofInput$Shape = {
 };
 
 export const SquashedOneofInput$Ref: InputObjectRef<SquashedOneofInput$Shape> =
-  builder.inputRef<SquashedOneofInput$Shape>("SquashedOneofInput").implement({
-    fields: (t) => ({
-      msg1: t.field({
-        type: OneofMessage1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "msg1",
-            typeFullName: "testapis.imports.squashed_union.pkg1.OneofMessage1",
+  builder
+    .inputRef<SquashedOneofInput$Shape>("SquashedOneofInput")
+    .implement({
+      fields: (t) => ({
+        msg1: t.field({
+          type: OneofMessage1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "msg1",
+              typeFullName:
+                "testapis.imports.squashed_union.pkg1.OneofMessage1",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.squashed_union.pkg1.SquashedOneof",
-        name: "SquashedOneof",
-        package: "testapis.imports.squashed_union.pkg1",
-        options: { "[graphql.object_type]": { squashUnion: true } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.squashed_union.pkg1.SquashedOneof",
+          name: "SquashedOneof",
+          package: "testapis.imports.squashed_union.pkg1",
+          options: { "[graphql.object_type]": { squashUnion: true } },
+        },
       },
-    },
-  });
+    });
 
 export function SquashedOneofInput$toProto(
   input: SquashedOneofInput$Shape | null | undefined,
@@ -104,11 +114,13 @@ export const SquashedOneof$Ref = builder.unionType("SquashedOneof", {
       fullName: "testapis.imports.squashed_union.pkg1.SquashedOneof",
       name: "SquashedOneof",
       package: "testapis.imports.squashed_union.pkg1",
-      fields: [{
-        name: "msg1",
-        type: "testapis.imports.squashed_union.pkg1.OneofMessage1",
-        options: { "[graphql.object_type]": { squashUnion: true } },
-      }],
+      fields: [
+        {
+          name: "msg1",
+          type: "testapis.imports.squashed_union.pkg1.OneofMessage1",
+          options: { "[graphql.object_type]": { squashUnion: true } },
+        },
+      ],
     },
   },
 });

--- a/tests/golden/protobuf-es-v1/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg2.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg2.pb.pothos.ts
@@ -46,10 +46,13 @@ builder.objectType(Message$Ref, {
   },
 });
 
-export type MessageInput$Shape = { msg?: SquashedOneofInput$Shape | null; };
+export type MessageInput$Shape = {
+  msg?: SquashedOneofInput$Shape | null;
+};
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       msg: t.field({
         type: SquashedOneofInput$Ref,

--- a/tests/golden/protobuf-es-v1/testapis.imports.transitive/__expected__/testapis/imports/transitive/a.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.transitive/__expected__/testapis/imports/transitive/a.pb.pothos.ts
@@ -34,32 +34,36 @@ builder.objectType(A$Ref, {
   },
 });
 
-export type AInput$Shape = { b?: BInput$Shape | null; };
+export type AInput$Shape = {
+  b?: BInput$Shape | null;
+};
 
-export const AInput$Ref: InputObjectRef<AInput$Shape> = builder.inputRef<
-  AInput$Shape
->("AInput").implement({
-  fields: (t) => ({
-    b: t.field({
-      type: BInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "b",
-          typeFullName: "testapis.imports.transitive.B",
+export const AInput$Ref: InputObjectRef<AInput$Shape> = builder
+  .inputRef<AInput$Shape>("AInput")
+  .implement({
+    fields: (t) => ({
+      b: t.field({
+        type: BInput$Ref,
+        required: false,
+        extensions: {
+          protobufField: {
+            name: "b",
+            typeFullName: "testapis.imports.transitive.B",
+          },
         },
-      },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.imports.transitive.A",
-      name: "A",
-      package: "testapis.imports.transitive",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.imports.transitive.A",
+        name: "A",
+        package: "testapis.imports.transitive",
+      },
     },
-  },
-});
+  });
 
 export function AInput$toProto(input: AInput$Shape | null | undefined): A {
-  return new A({ b: input?.b ? BInput$toProto(input.b) : undefined });
+  return new A({
+    b: input?.b ? BInput$toProto(input.b) : undefined,
+  });
 }

--- a/tests/golden/protobuf-es-v1/testapis.imports.transitive/__expected__/testapis/imports/transitive/b.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.transitive/__expected__/testapis/imports/transitive/b.pb.pothos.ts
@@ -34,32 +34,36 @@ builder.objectType(B$Ref, {
   },
 });
 
-export type BInput$Shape = { c?: CInput$Shape | null; };
+export type BInput$Shape = {
+  c?: CInput$Shape | null;
+};
 
-export const BInput$Ref: InputObjectRef<BInput$Shape> = builder.inputRef<
-  BInput$Shape
->("BInput").implement({
-  fields: (t) => ({
-    c: t.field({
-      type: CInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "c",
-          typeFullName: "testapis.imports.transitive.C",
+export const BInput$Ref: InputObjectRef<BInput$Shape> = builder
+  .inputRef<BInput$Shape>("BInput")
+  .implement({
+    fields: (t) => ({
+      c: t.field({
+        type: CInput$Ref,
+        required: false,
+        extensions: {
+          protobufField: {
+            name: "c",
+            typeFullName: "testapis.imports.transitive.C",
+          },
         },
-      },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.imports.transitive.B",
-      name: "B",
-      package: "testapis.imports.transitive",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.imports.transitive.B",
+        name: "B",
+        package: "testapis.imports.transitive",
+      },
     },
-  },
-});
+  });
 
 export function BInput$toProto(input: BInput$Shape | null | undefined): B {
-  return new B({ c: input?.c ? CInput$toProto(input.c) : undefined });
+  return new B({
+    c: input?.c ? CInput$toProto(input.c) : undefined,
+  });
 }

--- a/tests/golden/protobuf-es-v1/testapis.imports.transitive/__expected__/testapis/imports/transitive/c.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.imports.transitive/__expected__/testapis/imports/transitive/c.pb.pothos.ts
@@ -28,27 +28,31 @@ builder.objectType(C$Ref, {
   },
 });
 
-export type CInput$Shape = { body: C["body"]; };
+export type CInput$Shape = {
+  body: C["body"];
+};
 
-export const CInput$Ref: InputObjectRef<CInput$Shape> = builder.inputRef<
-  CInput$Shape
->("CInput").implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const CInput$Ref: InputObjectRef<CInput$Shape> = builder
+  .inputRef<CInput$Shape>("CInput")
+  .implement({
+    fields: (t) => ({
+      body: t.field({
+        type: "String",
+        required: true,
+        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.imports.transitive.C",
-      name: "C",
-      package: "testapis.imports.transitive",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.imports.transitive.C",
+        name: "C",
+        package: "testapis.imports.transitive",
+      },
     },
-  },
-});
+  });
 
 export function CInput$toProto(input: CInput$Shape | null | undefined): C {
-  return new C({ body: input?.body ?? undefined });
+  return new C({
+    body: input?.body ?? undefined,
+  });
 }

--- a/tests/golden/protobuf-es-v1/testapis.oneof.message_only/__expected__/testapis/oneof/message_only/message_only.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.oneof.message_only/__expected__/testapis/oneof/message_only/message_only.pb.pothos.ts
@@ -121,64 +121,66 @@ export type OneofParentInput$Shape = {
 };
 
 export const OneofParentInput$Ref: InputObjectRef<OneofParentInput$Shape> =
-  builder.inputRef<OneofParentInput$Shape>("OneofParentInput").implement({
-    fields: (t) => ({
-      normalField: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: { name: "normal_field", typeFullName: "string" },
-        },
-      }),
-      requiredMessage1: t.field({
-        type: OneofMemberMessage1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "required_message1",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+  builder
+    .inputRef<OneofParentInput$Shape>("OneofParentInput")
+    .implement({
+      fields: (t) => ({
+        normalField: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "normal_field", typeFullName: "string" },
           },
-        },
-      }),
-      requiredMessage2: t.field({
-        type: OneofMemberMessage2Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "required_message2",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+        }),
+        requiredMessage1: t.field({
+          type: OneofMemberMessage1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "required_message1",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+            },
           },
-        },
-      }),
-      optionalMessage1: t.field({
-        type: OneofMemberMessage1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "optional_message1",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+        }),
+        requiredMessage2: t.field({
+          type: OneofMemberMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "required_message2",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+            },
           },
-        },
-      }),
-      optionalMessage2: t.field({
-        type: OneofMemberMessage2Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "optional_message2",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+        }),
+        optionalMessage1: t.field({
+          type: OneofMemberMessage1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "optional_message1",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+            },
           },
-        },
+        }),
+        optionalMessage2: t.field({
+          type: OneofMemberMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "optional_message2",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.message_only.OneofParent",
-        name: "OneofParent",
-        package: "testapis.oneof.message_only",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.message_only.OneofParent",
+          name: "OneofParent",
+          package: "testapis.oneof.message_only",
+        },
       },
-    },
-  });
+    });
 
 export function OneofParentInput$toProto(
   input: OneofParentInput$Shape | null | undefined,
@@ -187,26 +189,26 @@ export function OneofParentInput$toProto(
     normalField: input?.normalField ?? undefined,
     requiredOneofMembers: input?.requiredMessage1
       ? {
-        case: "requiredMessage1",
-        value: OneofMemberMessage1Input$toProto(input.requiredMessage1),
-      }
+          case: "requiredMessage1",
+          value: OneofMemberMessage1Input$toProto(input.requiredMessage1),
+        }
       : input?.requiredMessage2
-      ? {
-        case: "requiredMessage2",
-        value: OneofMemberMessage2Input$toProto(input.requiredMessage2),
-      }
-      : undefined,
+        ? {
+            case: "requiredMessage2",
+            value: OneofMemberMessage2Input$toProto(input.requiredMessage2),
+          }
+        : undefined,
     optionalOneofMembers: input?.optionalMessage1
       ? {
-        case: "optionalMessage1",
-        value: OneofMemberMessage1Input$toProto(input.optionalMessage1),
-      }
+          case: "optionalMessage1",
+          value: OneofMemberMessage1Input$toProto(input.optionalMessage1),
+        }
       : input?.optionalMessage2
-      ? {
-        case: "optionalMessage2",
-        value: OneofMemberMessage2Input$toProto(input.optionalMessage2),
-      }
-      : undefined,
+        ? {
+            case: "optionalMessage2",
+            value: OneofMemberMessage2Input$toProto(input.optionalMessage2),
+          }
+        : undefined,
   });
 }
 
@@ -214,62 +216,68 @@ export type OneofMemberMessage1Input$Shape = {
   body: OneofMemberMessage1["body"];
 };
 
-export const OneofMemberMessage1Input$Ref: InputObjectRef<
-  OneofMemberMessage1Input$Shape
-> = builder.inputRef<OneofMemberMessage1Input$Shape>("OneofMemberMessage1Input")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const OneofMemberMessage1Input$Ref: InputObjectRef<OneofMemberMessage1Input$Shape> =
+  builder
+    .inputRef<OneofMemberMessage1Input$Shape>("OneofMemberMessage1Input")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.message_only.OneofMemberMessage1",
-        name: "OneofMemberMessage1",
-        package: "testapis.oneof.message_only",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.message_only.OneofMemberMessage1",
+          name: "OneofMemberMessage1",
+          package: "testapis.oneof.message_only",
+        },
       },
-    },
-  });
+    });
 
 export function OneofMemberMessage1Input$toProto(
   input: OneofMemberMessage1Input$Shape | null | undefined,
 ): OneofMemberMessage1 {
-  return new OneofMemberMessage1({ body: input?.body ?? undefined });
+  return new OneofMemberMessage1({
+    body: input?.body ?? undefined,
+  });
 }
 
 export type OneofMemberMessage2Input$Shape = {
   imageUrl: OneofMemberMessage2["imageUrl"];
 };
 
-export const OneofMemberMessage2Input$Ref: InputObjectRef<
-  OneofMemberMessage2Input$Shape
-> = builder.inputRef<OneofMemberMessage2Input$Shape>("OneofMemberMessage2Input")
-  .implement({
-    fields: (t) => ({
-      imageUrl: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: { name: "image_url", typeFullName: "string" },
-        },
+export const OneofMemberMessage2Input$Ref: InputObjectRef<OneofMemberMessage2Input$Shape> =
+  builder
+    .inputRef<OneofMemberMessage2Input$Shape>("OneofMemberMessage2Input")
+    .implement({
+      fields: (t) => ({
+        imageUrl: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "image_url", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.message_only.OneofMemberMessage2",
-        name: "OneofMemberMessage2",
-        package: "testapis.oneof.message_only",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.message_only.OneofMemberMessage2",
+          name: "OneofMemberMessage2",
+          package: "testapis.oneof.message_only",
+        },
       },
-    },
-  });
+    });
 
 export function OneofMemberMessage2Input$toProto(
   input: OneofMemberMessage2Input$Shape | null | undefined,
 ): OneofMemberMessage2 {
-  return new OneofMemberMessage2({ imageUrl: input?.imageUrl ?? undefined });
+  return new OneofMemberMessage2({
+    imageUrl: input?.imageUrl ?? undefined,
+  });
 }
 
 export const OneofParentRequiredOneofMembers$Ref = builder.unionType(
@@ -284,13 +292,16 @@ export const OneofParentRequiredOneofMembers$Ref = builder.unionType(
         name: "required_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "required_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "required_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "required_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "required_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },
@@ -307,13 +318,16 @@ export const OneofParentOptionalOneofMembers$Ref = builder.unionType(
         name: "optional_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "optional_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "optional_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "optional_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "optional_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },

--- a/tests/golden/protobuf-es-v1/testapis.oneof.non_message/__expected__/testapis/oneof/non_message/non_message.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.oneof.non_message/__expected__/testapis/oneof/non_message/non_message.pb.pothos.ts
@@ -38,9 +38,8 @@ builder.objectType(OneofParent$Ref, {
   },
 });
 
-export const MessageMember$Ref = builder.objectRef<MessageMember>(
-  "MessageMember",
-);
+export const MessageMember$Ref =
+  builder.objectRef<MessageMember>("MessageMember");
 builder.objectType(MessageMember$Ref, {
   name: "MessageMember",
   fields: (t) => ({
@@ -67,27 +66,29 @@ export type OneofParentInput$Shape = {
 };
 
 export const OneofParentInput$Ref: InputObjectRef<OneofParentInput$Shape> =
-  builder.inputRef<OneofParentInput$Shape>("OneofParentInput").implement({
-    fields: (t) => ({
-      member: t.field({
-        type: MessageMemberInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "member",
-            typeFullName: "testapis.oneof.non_message.MessageMember",
+  builder
+    .inputRef<OneofParentInput$Shape>("OneofParentInput")
+    .implement({
+      fields: (t) => ({
+        member: t.field({
+          type: MessageMemberInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "member",
+              typeFullName: "testapis.oneof.non_message.MessageMember",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.non_message.OneofParent",
-        name: "OneofParent",
-        package: "testapis.oneof.non_message",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.non_message.OneofParent",
+          name: "OneofParent",
+          package: "testapis.oneof.non_message",
+        },
       },
-    },
-  });
+    });
 
 export function OneofParentInput$toProto(
   input: OneofParentInput$Shape | null | undefined,
@@ -99,30 +100,38 @@ export function OneofParentInput$toProto(
   });
 }
 
-export type MessageMemberInput$Shape = { body: MessageMember["body"]; };
+export type MessageMemberInput$Shape = {
+  body: MessageMember["body"];
+};
 
 export const MessageMemberInput$Ref: InputObjectRef<MessageMemberInput$Shape> =
-  builder.inputRef<MessageMemberInput$Shape>("MessageMemberInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<MessageMemberInput$Shape>("MessageMemberInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.non_message.MessageMember",
-        name: "MessageMember",
-        package: "testapis.oneof.non_message",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.non_message.MessageMember",
+          name: "MessageMember",
+          package: "testapis.oneof.non_message",
+        },
       },
-    },
-  });
+    });
 
 export function MessageMemberInput$toProto(
   input: MessageMemberInput$Shape | null | undefined,
 ): MessageMember {
-  return new MessageMember({ body: input?.body ?? undefined });
+  return new MessageMember({
+    body: input?.body ?? undefined,
+  });
 }
 
 export const OneofParentMixedOneofMembers$Ref = builder.unionType(
@@ -135,10 +144,9 @@ export const OneofParentMixedOneofMembers$Ref = builder.unionType(
         name: "mixed_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.non_message",
-        fields: [{
-          name: "member",
-          type: "testapis.oneof.non_message.MessageMember",
-        }],
+        fields: [
+          { name: "member", type: "testapis.oneof.non_message.MessageMember" },
+        ],
       },
     },
   },

--- a/tests/golden/protobuf-es-v1/testapis.options.deprecation/__expected__/testapis/options/deprecation/deprecation.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.options.deprecation/__expected__/testapis/options/deprecation/deprecation.pb.pothos.ts
@@ -14,9 +14,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es/lib/testapis/options/deprecation/deprecation_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const DeprecatedMessage$Ref = builder.objectRef<DeprecatedMessage>(
-  "DeprecatedMessage",
-);
+export const DeprecatedMessage$Ref =
+  builder.objectRef<DeprecatedMessage>("DeprecatedMessage");
 builder.objectType(DeprecatedMessage$Ref, {
   name: "DeprecatedMessage",
   fields: (t) => ({
@@ -139,9 +138,10 @@ builder.objectType(NotDeprecatedMessage$Ref, {
   },
 });
 
-export const DeprecatedMessageInnerMessage$Ref = builder.objectRef<
-  DeprecatedMessage_InnerMessage
->("DeprecatedMessageInnerMessage");
+export const DeprecatedMessageInnerMessage$Ref =
+  builder.objectRef<DeprecatedMessage_InnerMessage>(
+    "DeprecatedMessageInnerMessage",
+  );
 builder.objectType(DeprecatedMessageInnerMessage$Ref, {
   name: "DeprecatedMessageInnerMessage",
   fields: (t) => ({
@@ -165,9 +165,10 @@ builder.objectType(DeprecatedMessageInnerMessage$Ref, {
   },
 });
 
-export const NotDeprecatedMessageInnerMessage1$Ref = builder.objectRef<
-  NotDeprecatedMessage_InnerMessage1
->("NotDeprecatedMessageInnerMessage1");
+export const NotDeprecatedMessageInnerMessage1$Ref =
+  builder.objectRef<NotDeprecatedMessage_InnerMessage1>(
+    "NotDeprecatedMessageInnerMessage1",
+  );
 builder.objectType(NotDeprecatedMessageInnerMessage1$Ref, {
   name: "NotDeprecatedMessageInnerMessage1",
   fields: (t) => ({
@@ -192,9 +193,10 @@ builder.objectType(NotDeprecatedMessageInnerMessage1$Ref, {
   },
 });
 
-export const NotDeprecatedMessageInnerMessage2$Ref = builder.objectRef<
-  NotDeprecatedMessage_InnerMessage2
->("NotDeprecatedMessageInnerMessage2");
+export const NotDeprecatedMessageInnerMessage2$Ref =
+  builder.objectRef<NotDeprecatedMessage_InnerMessage2>(
+    "NotDeprecatedMessageInnerMessage2",
+  );
 builder.objectType(NotDeprecatedMessageInnerMessage2$Ref, {
   name: "NotDeprecatedMessageInnerMessage2",
   fields: (t) => ({
@@ -224,40 +226,42 @@ export type DeprecatedMessageInput$Shape = {
   enum?: DeprecatedMessage["enum"] | null;
 };
 
-export const DeprecatedMessageInput$Ref: InputObjectRef<
-  DeprecatedMessageInput$Shape
-> = builder.inputRef<DeprecatedMessageInput$Shape>("DeprecatedMessageInput")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: false,
-        deprecationReason:
-          "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      enum: t.field({
-        type: NotDeprecatedEnum$Ref,
-        required: false,
-        deprecationReason:
-          "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-        extensions: {
-          protobufField: {
-            name: "enum",
-            typeFullName: "testapis.options.deprecation.NotDeprecatedEnum",
+export const DeprecatedMessageInput$Ref: InputObjectRef<DeprecatedMessageInput$Shape> =
+  builder
+    .inputRef<DeprecatedMessageInput$Shape>("DeprecatedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
+        }),
+        enum: t.field({
+          type: NotDeprecatedEnum$Ref,
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: {
+              name: "enum",
+              typeFullName: "testapis.options.deprecation.NotDeprecatedEnum",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.deprecation.DeprecatedMessage",
-        name: "DeprecatedMessage",
-        package: "testapis.options.deprecation",
-        options: { deprecated: true },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.deprecation.DeprecatedMessage",
+          name: "DeprecatedMessage",
+          package: "testapis.options.deprecation",
+          options: { deprecated: true },
+        },
       },
-    },
-  });
+    });
 
 export function DeprecatedMessageInput$toProto(
   input: DeprecatedMessageInput$Shape | null | undefined,
@@ -277,100 +281,99 @@ export type NotDeprecatedMessageInput$Shape = {
   msg4?: NotDeprecatedMessageInnerMessage2Input$Shape | null;
 };
 
-export const NotDeprecatedMessageInput$Ref: InputObjectRef<
-  NotDeprecatedMessageInput$Shape
-> = builder.inputRef<NotDeprecatedMessageInput$Shape>(
-  "NotDeprecatedMessageInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.NotDeprecatedMessage.body is mark as deprecated in a *.proto file.",
+export const NotDeprecatedMessageInput$Ref: InputObjectRef<NotDeprecatedMessageInput$Shape> =
+  builder
+    .inputRef<NotDeprecatedMessageInput$Shape>("NotDeprecatedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.NotDeprecatedMessage.body is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "body",
+              typeFullName: "string",
+              options: { deprecated: true },
+            },
+          },
+        }),
+        enum: t.field({
+          type: DeprecatedEnum$Ref,
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "enum",
+              typeFullName: "testapis.options.deprecation.DeprecatedEnum",
+            },
+          },
+        }),
+        msg1: t.field({
+          type: NotDeprecatedMessageInnerMessage1Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: {
+              name: "msg1",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+            },
+          },
+        }),
+        msg2: t.field({
+          type: NotDeprecatedMessageInnerMessage2Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: {
+              name: "msg2",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+            },
+          },
+        }),
+        msg3: t.field({
+          type: NotDeprecatedMessageInnerMessage1Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.NotDeprecatedMessage.msg3 is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "msg3",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+              options: { deprecated: true },
+            },
+          },
+        }),
+        msg4: t.field({
+          type: NotDeprecatedMessageInnerMessage2Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.NotDeprecatedMessage.msg4 is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "msg4",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+              options: { deprecated: true },
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "body",
-          typeFullName: "string",
-          options: { deprecated: true },
+        protobufMessage: {
+          fullName: "testapis.options.deprecation.NotDeprecatedMessage",
+          name: "NotDeprecatedMessage",
+          package: "testapis.options.deprecation",
         },
       },
-    }),
-    enum: t.field({
-      type: DeprecatedEnum$Ref,
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.",
-      extensions: {
-        protobufField: {
-          name: "enum",
-          typeFullName: "testapis.options.deprecation.DeprecatedEnum",
-        },
-      },
-    }),
-    msg1: t.field({
-      type: NotDeprecatedMessageInnerMessage1Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: {
-        protobufField: {
-          name: "msg1",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-        },
-      },
-    }),
-    msg2: t.field({
-      type: NotDeprecatedMessageInnerMessage2Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: {
-        protobufField: {
-          name: "msg2",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-        },
-      },
-    }),
-    msg3: t.field({
-      type: NotDeprecatedMessageInnerMessage1Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.NotDeprecatedMessage.msg3 is mark as deprecated in a *.proto file.",
-      extensions: {
-        protobufField: {
-          name: "msg3",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-          options: { deprecated: true },
-        },
-      },
-    }),
-    msg4: t.field({
-      type: NotDeprecatedMessageInnerMessage2Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.NotDeprecatedMessage.msg4 is mark as deprecated in a *.proto file.",
-      extensions: {
-        protobufField: {
-          name: "msg4",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-          options: { deprecated: true },
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.deprecation.NotDeprecatedMessage",
-      name: "NotDeprecatedMessage",
-      package: "testapis.options.deprecation",
-    },
-  },
-});
+    });
 
 export function NotDeprecatedMessageInput$toProto(
   input: NotDeprecatedMessageInput$Shape | null | undefined,
@@ -380,26 +383,26 @@ export function NotDeprecatedMessageInput$toProto(
     enum: input?.enum ?? undefined,
     notDeprecatedOneof: input?.msg1
       ? {
-        case: "msg1",
-        value: NotDeprecatedMessageInnerMessage1Input$toProto(input.msg1),
-      }
+          case: "msg1",
+          value: NotDeprecatedMessageInnerMessage1Input$toProto(input.msg1),
+        }
       : input?.msg2
-      ? {
-        case: "msg2",
-        value: NotDeprecatedMessageInnerMessage2Input$toProto(input.msg2),
-      }
-      : undefined,
+        ? {
+            case: "msg2",
+            value: NotDeprecatedMessageInnerMessage2Input$toProto(input.msg2),
+          }
+        : undefined,
     deprecatedOneof: input?.msg3
       ? {
-        case: "msg3",
-        value: NotDeprecatedMessageInnerMessage1Input$toProto(input.msg3),
-      }
+          case: "msg3",
+          value: NotDeprecatedMessageInnerMessage1Input$toProto(input.msg3),
+        }
       : input?.msg4
-      ? {
-        case: "msg4",
-        value: NotDeprecatedMessageInnerMessage2Input$toProto(input.msg4),
-      }
-      : undefined,
+        ? {
+            case: "msg4",
+            value: NotDeprecatedMessageInnerMessage2Input$toProto(input.msg4),
+          }
+        : undefined,
   });
 }
 
@@ -407,62 +410,71 @@ export type DeprecatedMessageInnerMessageInput$Shape = {
   body?: DeprecatedMessage_InnerMessage["body"] | null;
 };
 
-export const DeprecatedMessageInnerMessageInput$Ref: InputObjectRef<
-  DeprecatedMessageInnerMessageInput$Shape
-> = builder.inputRef<DeprecatedMessageInnerMessageInput$Shape>(
-  "DeprecatedMessageInnerMessageInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.deprecation.DeprecatedMessage.InnerMessage",
-      name: "InnerMessage",
-      package: "testapis.options.deprecation",
-    },
-  },
-});
+export const DeprecatedMessageInnerMessageInput$Ref: InputObjectRef<DeprecatedMessageInnerMessageInput$Shape> =
+  builder
+    .inputRef<DeprecatedMessageInnerMessageInput$Shape>(
+      "DeprecatedMessageInnerMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.deprecation.DeprecatedMessage.InnerMessage",
+          name: "InnerMessage",
+          package: "testapis.options.deprecation",
+        },
+      },
+    });
 
 export function DeprecatedMessageInnerMessageInput$toProto(
   input: DeprecatedMessageInnerMessageInput$Shape | null | undefined,
 ): DeprecatedMessage_InnerMessage {
-  return new DeprecatedMessage_InnerMessage({ body: input?.body ?? undefined });
+  return new DeprecatedMessage_InnerMessage({
+    body: input?.body ?? undefined,
+  });
 }
 
 export type NotDeprecatedMessageInnerMessage1Input$Shape = {
   body?: NotDeprecatedMessage_InnerMessage1["body"] | null;
 };
 
-export const NotDeprecatedMessageInnerMessage1Input$Ref: InputObjectRef<
-  NotDeprecatedMessageInnerMessage1Input$Shape
-> = builder.inputRef<NotDeprecatedMessageInnerMessage1Input$Shape>(
-  "NotDeprecatedMessageInnerMessage1Input",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-      name: "InnerMessage1",
-      package: "testapis.options.deprecation",
-    },
-  },
-});
+export const NotDeprecatedMessageInnerMessage1Input$Ref: InputObjectRef<NotDeprecatedMessageInnerMessage1Input$Shape> =
+  builder
+    .inputRef<NotDeprecatedMessageInnerMessage1Input$Shape>(
+      "NotDeprecatedMessageInnerMessage1Input",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+          name: "InnerMessage1",
+          package: "testapis.options.deprecation",
+        },
+      },
+    });
 
 export function NotDeprecatedMessageInnerMessage1Input$toProto(
   input: NotDeprecatedMessageInnerMessage1Input$Shape | null | undefined,
@@ -476,29 +488,32 @@ export type NotDeprecatedMessageInnerMessage2Input$Shape = {
   body?: NotDeprecatedMessage_InnerMessage2["body"] | null;
 };
 
-export const NotDeprecatedMessageInnerMessage2Input$Ref: InputObjectRef<
-  NotDeprecatedMessageInnerMessage2Input$Shape
-> = builder.inputRef<NotDeprecatedMessageInnerMessage2Input$Shape>(
-  "NotDeprecatedMessageInnerMessage2Input",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-      name: "InnerMessage2",
-      package: "testapis.options.deprecation",
-    },
-  },
-});
+export const NotDeprecatedMessageInnerMessage2Input$Ref: InputObjectRef<NotDeprecatedMessageInnerMessage2Input$Shape> =
+  builder
+    .inputRef<NotDeprecatedMessageInnerMessage2Input$Shape>(
+      "NotDeprecatedMessageInnerMessage2Input",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+          name: "InnerMessage2",
+          package: "testapis.options.deprecation",
+        },
+      },
+    });
 
 export function NotDeprecatedMessageInnerMessage2Input$toProto(
   input: NotDeprecatedMessageInnerMessage2Input$Shape | null | undefined,
@@ -522,15 +537,16 @@ export const NotDeprecatedMessageNotDeprecatedOneof$Ref = builder.unionType(
         name: "not_deprecated_oneof",
         messageName: "NotDeprecatedMessage",
         package: "testapis.options.deprecation",
-        fields: [{
-          name: "msg1",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-        }, {
-          name: "msg2",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-        }],
+        fields: [
+          {
+            name: "msg1",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+          },
+          {
+            name: "msg2",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+          },
+        ],
       },
     },
   },
@@ -550,15 +566,16 @@ export const NotDeprecatedMessageDeprecatedOneof$Ref = builder.unionType(
         name: "deprecated_oneof",
         messageName: "NotDeprecatedMessage",
         package: "testapis.options.deprecation",
-        fields: [{
-          name: "msg3",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-        }, {
-          name: "msg4",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-        }],
+        fields: [
+          {
+            name: "msg3",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+          },
+          {
+            name: "msg4",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+          },
+        ],
       },
     },
   },

--- a/tests/golden/protobuf-es-v1/testapis.options.field_nullability/__expected__/testapis/options/field_nullability/field_nullability.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.options.field_nullability/__expected__/testapis/options/field_nullability/field_nullability.pb.pothos.ts
@@ -81,7 +81,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       userId: t.field({
         type: "Int64",

--- a/tests/golden/protobuf-es-v1/testapis.options.input_no_partial/__expected__/testapis/options/input_no_partial/input_no_partial.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.options.input_no_partial/__expected__/testapis/options/input_no_partial/input_no_partial.pb.pothos.ts
@@ -10,9 +10,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es/lib/testapis/options/input_no_partial/input_no_partial_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const ParentMessage$Ref = builder.objectRef<ParentMessage>(
-  "ParentMessage",
-);
+export const ParentMessage$Ref =
+  builder.objectRef<ParentMessage>("ParentMessage");
 builder.objectType(ParentMessage$Ref, {
   name: "ParentMessage",
   fields: (t) => ({
@@ -59,9 +58,8 @@ builder.objectType(ParentMessage$Ref, {
   },
 });
 
-export const PartialableInputMessage$Ref = builder.objectRef<
-  PartialableInputMessage
->("PartialableInputMessage");
+export const PartialableInputMessage$Ref =
+  builder.objectRef<PartialableInputMessage>("PartialableInputMessage");
 builder.objectType(PartialableInputMessage$Ref, {
   name: "PartialableInputMessage",
   fields: (t) => ({
@@ -90,9 +88,8 @@ builder.objectType(PartialableInputMessage$Ref, {
   },
 });
 
-export const NoPartialInputMessage$Ref = builder.objectRef<
-  NoPartialInputMessage
->("NoPartialInputMessage");
+export const NoPartialInputMessage$Ref =
+  builder.objectRef<NoPartialInputMessage>("NoPartialInputMessage");
 builder.objectType(NoPartialInputMessage$Ref, {
   name: "NoPartialInputMessage",
   fields: (t) => ({
@@ -128,41 +125,43 @@ export type ParentMessageInput$Shape = {
 };
 
 export const ParentMessageInput$Ref: InputObjectRef<ParentMessageInput$Shape> =
-  builder.inputRef<ParentMessageInput$Shape>("ParentMessageInput").implement({
-    fields: (t) => ({
-      partialableInputMessage: t.field({
-        type: PartialableInputMessageInput$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "partialable_input_message",
-            typeFullName:
-              "testapis.options.input_no_partial.PartialableInputMessage",
+  builder
+    .inputRef<ParentMessageInput$Shape>("ParentMessageInput")
+    .implement({
+      fields: (t) => ({
+        partialableInputMessage: t.field({
+          type: PartialableInputMessageInput$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "partialable_input_message",
+              typeFullName:
+                "testapis.options.input_no_partial.PartialableInputMessage",
+            },
           },
-        },
-      }),
-      noPartialInputMessage: t.field({
-        type: NoPartialInputMessageInput$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "no_partial_input_message",
-            typeFullName:
-              "testapis.options.input_no_partial.NoPartialInputMessage",
+        }),
+        noPartialInputMessage: t.field({
+          type: NoPartialInputMessageInput$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "no_partial_input_message",
+              typeFullName:
+                "testapis.options.input_no_partial.NoPartialInputMessage",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.input_no_partial.ParentMessage",
-        name: "ParentMessage",
-        package: "testapis.options.input_no_partial",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.input_no_partial.ParentMessage",
+          name: "ParentMessage",
+          package: "testapis.options.input_no_partial",
+        },
       },
-    },
-  });
+    });
 
 export function ParentMessageInput$toProto(
   input: ParentMessageInput$Shape | null | undefined,
@@ -182,33 +181,36 @@ export type PartialableInputMessageInput$Shape = {
   body: PartialableInputMessage["body"];
 };
 
-export const PartialableInputMessageInput$Ref: InputObjectRef<
-  PartialableInputMessageInput$Shape
-> = builder.inputRef<PartialableInputMessageInput$Shape>(
-  "PartialableInputMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.input_no_partial.PartialableInputMessage",
-      name: "PartialableInputMessage",
-      package: "testapis.options.input_no_partial",
-    },
-  },
-});
+export const PartialableInputMessageInput$Ref: InputObjectRef<PartialableInputMessageInput$Shape> =
+  builder
+    .inputRef<PartialableInputMessageInput$Shape>(
+      "PartialableInputMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          description: "Required.",
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.input_no_partial.PartialableInputMessage",
+          name: "PartialableInputMessage",
+          package: "testapis.options.input_no_partial",
+        },
+      },
+    });
 
 export function PartialableInputMessageInput$toProto(
   input: PartialableInputMessageInput$Shape | null | undefined,
@@ -224,34 +226,35 @@ export type NoPartialInputMessageInput$Shape = {
   body: NoPartialInputMessage["body"];
 };
 
-export const NoPartialInputMessageInput$Ref: InputObjectRef<
-  NoPartialInputMessageInput$Shape
-> = builder.inputRef<NoPartialInputMessageInput$Shape>(
-  "NoPartialInputMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.input_no_partial.NoPartialInputMessage",
-      name: "NoPartialInputMessage",
-      package: "testapis.options.input_no_partial",
-      options: { "[graphql.input_type]": { noPartial: true } },
-    },
-  },
-});
+export const NoPartialInputMessageInput$Ref: InputObjectRef<NoPartialInputMessageInput$Shape> =
+  builder
+    .inputRef<NoPartialInputMessageInput$Shape>("NoPartialInputMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          description: "Required.",
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.input_no_partial.NoPartialInputMessage",
+          name: "NoPartialInputMessage",
+          package: "testapis.options.input_no_partial",
+          options: { "[graphql.input_type]": { noPartial: true } },
+        },
+      },
+    });
 
 export function NoPartialInputMessageInput$toProto(
   input: NoPartialInputMessageInput$Shape | null | undefined,

--- a/tests/golden/protobuf-es-v1/testapis.options.message_and_field/__expected__/testapis/options/message_and_field/message_and_field.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.options.message_and_field/__expected__/testapis/options/message_and_field/message_and_field.pb.pothos.ts
@@ -18,9 +18,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es/lib/testapis/options/message_and_field/message_and_field_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const PrefixedMessage$Ref = builder.objectRef<PrefixedMessage>(
-  "PrefixedMessage",
-);
+export const PrefixedMessage$Ref =
+  builder.objectRef<PrefixedMessage>("PrefixedMessage");
 builder.objectType(PrefixedMessage$Ref, {
   name: "PrefixedMessage",
   fields: (t) => ({
@@ -186,9 +185,8 @@ builder.objectType(PrefixedMessage$Ref, {
   },
 });
 
-export const RenamedMessage$Ref = builder.objectRef<MessageWillRename>(
-  "RenamedMessage",
-);
+export const RenamedMessage$Ref =
+  builder.objectRef<MessageWillRename>("RenamedMessage");
 builder.objectType(RenamedMessage$Ref, {
   name: "RenamedMessage",
   fields: (t) => ({
@@ -211,9 +209,8 @@ builder.objectType(RenamedMessage$Ref, {
   },
 });
 
-export const MessageOnlyOutput$Ref = builder.objectRef<MessageOnlyOutput>(
-  "MessageOnlyOutput",
-);
+export const MessageOnlyOutput$Ref =
+  builder.objectRef<MessageOnlyOutput>("MessageOnlyOutput");
 builder.objectType(MessageOnlyOutput$Ref, {
   name: "MessageOnlyOutput",
   fields: (t) => ({
@@ -236,9 +233,10 @@ builder.objectType(MessageOnlyOutput$Ref, {
   },
 });
 
-export const PrefixedMessageInnerMessage$Ref = builder.objectRef<
-  PrefixedMessage_InnerMessage
->("PrefixedMessageInnerMessage");
+export const PrefixedMessageInnerMessage$Ref =
+  builder.objectRef<PrefixedMessage_InnerMessage>(
+    "PrefixedMessageInnerMessage",
+  );
 builder.objectType(PrefixedMessageInnerMessage$Ref, {
   name: "PrefixedMessageInnerMessage",
   fields: (t) => ({
@@ -266,9 +264,10 @@ builder.objectType(PrefixedMessageInnerMessage$Ref, {
   },
 });
 
-export const PrefixedMessageInnerMessage2$Ref = builder.objectRef<
-  PrefixedMessage_InnerMessage2
->("PrefixedMessageInnerMessage2");
+export const PrefixedMessageInnerMessage2$Ref =
+  builder.objectRef<PrefixedMessage_InnerMessage2>(
+    "PrefixedMessageInnerMessage2",
+  );
 builder.objectType(PrefixedMessageInnerMessage2$Ref, {
   name: "PrefixedMessageInnerMessage2",
   fields: (t) => ({
@@ -296,9 +295,8 @@ builder.objectType(PrefixedMessageInnerMessage2$Ref, {
   },
 });
 
-export const IgnoredMessageNotIgnored$Ref = builder.objectRef<
-  IgnoredMessage_NotIgnored
->("IgnoredMessageNotIgnored");
+export const IgnoredMessageNotIgnored$Ref =
+  builder.objectRef<IgnoredMessage_NotIgnored>("IgnoredMessageNotIgnored");
 builder.objectType(IgnoredMessageNotIgnored$Ref, {
   name: "IgnoredMessageNotIgnored",
   fields: (t) => ({
@@ -334,133 +332,135 @@ export type PrefixedMessageInput$Shape = {
   squashedMessages?: Array<PrefixedMessageSquashedMessageInput$Shape> | null;
 };
 
-export const PrefixedMessageInput$Ref: InputObjectRef<
-  PrefixedMessageInput$Shape
-> = builder.inputRef<PrefixedMessageInput$Shape>("PrefixedMessageInput")
-  .implement({
-    fields: (t) => ({
-      id: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "id",
-            typeFullName: "uint64",
-            options: { "[graphql.field]": { id: true } },
+export const PrefixedMessageInput$Ref: InputObjectRef<PrefixedMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInput$Shape>("PrefixedMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "id",
+              typeFullName: "uint64",
+              options: { "[graphql.field]": { id: true } },
+            },
           },
-        },
-      }),
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      prefixedEnum: t.field({
-        type: PrefixedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "prefixed_enum",
-            typeFullName: "testapis.options.message_and_field.PrefixedEnum",
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
-      }),
-      thisFieldWasRenamed: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "this_field_will_be_renamed",
-            typeFullName: "string",
-            options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
+        }),
+        prefixedEnum: t.field({
+          type: PrefixedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "prefixed_enum",
+              typeFullName: "testapis.options.message_and_field.PrefixedEnum",
+            },
           },
-        },
-      }),
-      skipResolver: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "skip_resolver",
-            typeFullName: "string",
-            options: { "[graphql.field]": { skipResolver: true } },
+        }),
+        thisFieldWasRenamed: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "this_field_will_be_renamed",
+              typeFullName: "string",
+              options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
+            },
           },
-        },
-      }),
-      squashedMessage: t.field({
-        type: PrefixedMessageSquashedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "squashed_message",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+        }),
+        skipResolver: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "skip_resolver",
+              typeFullName: "string",
+              options: { "[graphql.field]": { skipResolver: true } },
+            },
           },
-        },
-      }),
-      renamedMessage: t.field({
-        type: RenamedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "renamed_message",
-            typeFullName:
-              "testapis.options.message_and_field.MessageWillRename",
+        }),
+        squashedMessage: t.field({
+          type: PrefixedMessageSquashedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "squashed_message",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
           },
-        },
-      }),
-      renamedEnum: t.field({
-        type: RenamedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "renamed_enum",
-            typeFullName: "testapis.options.message_and_field.EnumWillRename",
+        }),
+        renamedMessage: t.field({
+          type: RenamedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_message",
+              typeFullName:
+                "testapis.options.message_and_field.MessageWillRename",
+            },
           },
-        },
-      }),
-      notIgnoredMessage: t.field({
-        type: IgnoredMessageNotIgnoredInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "not_ignored_message",
-            typeFullName:
-              "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+        }),
+        renamedEnum: t.field({
+          type: RenamedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_enum",
+              typeFullName: "testapis.options.message_and_field.EnumWillRename",
+            },
           },
-        },
-      }),
-      oneofNotIgnoredField: t.field({
-        type: PrefixedMessageInnerMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "oneof_not_ignored_field",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+        }),
+        notIgnoredMessage: t.field({
+          type: IgnoredMessageNotIgnoredInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "not_ignored_message",
+              typeFullName:
+                "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+            },
           },
-        },
-      }),
-      squashedMessages: t.field({
-        type: [PrefixedMessageSquashedMessageInput$Ref],
-        required: { list: false, items: true },
-        extensions: {
-          protobufField: {
-            name: "squashed_messages",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+        }),
+        oneofNotIgnoredField: t.field({
+          type: PrefixedMessageInnerMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_not_ignored_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
           },
-        },
+        }),
+        squashedMessages: t.field({
+          type: [PrefixedMessageSquashedMessageInput$Ref],
+          required: { list: false, items: true },
+          extensions: {
+            protobufField: {
+              name: "squashed_messages",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.PrefixedMessage",
-        name: "PrefixedMessage",
-        package: "testapis.options.message_and_field",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.PrefixedMessage",
+          name: "PrefixedMessage",
+          package: "testapis.options.message_and_field",
+        },
       },
-    },
-  });
+    });
 
 export function PrefixedMessageInput$toProto(
   input: PrefixedMessageInput$Shape | null | undefined,
@@ -482,75 +482,85 @@ export function PrefixedMessageInput$toProto(
       ? IgnoredMessageNotIgnoredInput$toProto(input.notIgnoredMessage)
       : undefined,
     squashedMessages: input?.squashedMessages?.map((v) =>
-      PrefixedMessageSquashedMessageInput$toProto(v)
+      PrefixedMessageSquashedMessageInput$toProto(v),
     ),
     partialIgnoreOneof: input?.oneofNotIgnoredField
       ? {
-        case: "oneofNotIgnoredField",
-        value: PrefixedMessageInnerMessageInput$toProto(
-          input.oneofNotIgnoredField,
-        ),
-      }
+          case: "oneofNotIgnoredField",
+          value: PrefixedMessageInnerMessageInput$toProto(
+            input.oneofNotIgnoredField,
+          ),
+        }
       : undefined,
   });
 }
 
-export type RenamedMessageInput$Shape = { body: MessageWillRename["body"]; };
+export type RenamedMessageInput$Shape = {
+  body: MessageWillRename["body"];
+};
 
-export const RenamedMessageInput$Ref: InputObjectRef<
-  RenamedMessageInput$Shape
-> = builder.inputRef<RenamedMessageInput$Shape>("RenamedMessageInput")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const RenamedMessageInput$Ref: InputObjectRef<RenamedMessageInput$Shape> =
+  builder
+    .inputRef<RenamedMessageInput$Shape>("RenamedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.MessageWillRename",
-        name: "MessageWillRename",
-        package: "testapis.options.message_and_field",
-        options: { "[graphql.object_type]": { name: "RenamedMessage" } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.MessageWillRename",
+          name: "MessageWillRename",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { name: "RenamedMessage" } },
+        },
       },
-    },
-  });
+    });
 
 export function RenamedMessageInput$toProto(
   input: RenamedMessageInput$Shape | null | undefined,
 ): MessageWillRename {
-  return new MessageWillRename({ body: input?.body ?? undefined });
+  return new MessageWillRename({
+    body: input?.body ?? undefined,
+  });
 }
 
-export type InterfaceMessageInput$Shape = { id: InterfaceMessage["id"]; };
+export type InterfaceMessageInput$Shape = {
+  id: InterfaceMessage["id"];
+};
 
-export const InterfaceMessageInput$Ref: InputObjectRef<
-  InterfaceMessageInput$Shape
-> = builder.inputRef<InterfaceMessageInput$Shape>("InterfaceMessageInput")
-  .implement({
-    fields: (t) => ({
-      id: t.field({
-        type: "Int64",
-        required: true,
-        extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+export const InterfaceMessageInput$Ref: InputObjectRef<InterfaceMessageInput$Shape> =
+  builder
+    .inputRef<InterfaceMessageInput$Shape>("InterfaceMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.InterfaceMessage",
-        name: "InterfaceMessage",
-        package: "testapis.options.message_and_field",
-        options: { "[graphql.object_type]": { interface: true } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.InterfaceMessage",
+          name: "InterfaceMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { interface: true } },
+        },
       },
-    },
-  });
+    });
 
 export function InterfaceMessageInput$toProto(
   input: InterfaceMessageInput$Shape | null | undefined,
 ): InterfaceMessage {
-  return new InterfaceMessage({ id: input?.id ?? undefined });
+  return new InterfaceMessage({
+    id: input?.id ?? undefined,
+  });
 }
 
 export type PrefixedMessageInnerMessageInput$Shape = {
@@ -558,32 +568,35 @@ export type PrefixedMessageInnerMessageInput$Shape = {
   body: PrefixedMessage_InnerMessage["body"];
 };
 
-export const PrefixedMessageInnerMessageInput$Ref: InputObjectRef<
-  PrefixedMessageInnerMessageInput$Shape
-> = builder.inputRef<PrefixedMessageInnerMessageInput$Shape>(
-  "PrefixedMessageInnerMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-      name: "InnerMessage",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const PrefixedMessageInnerMessageInput$Ref: InputObjectRef<PrefixedMessageInnerMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessageInput$Shape>(
+      "PrefixedMessageInnerMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+          name: "InnerMessage",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export function PrefixedMessageInnerMessageInput$toProto(
   input: PrefixedMessageInnerMessageInput$Shape | null | undefined,
@@ -599,32 +612,35 @@ export type PrefixedMessageInnerMessage2Input$Shape = {
   body: PrefixedMessage_InnerMessage2["body"];
 };
 
-export const PrefixedMessageInnerMessage2Input$Ref: InputObjectRef<
-  PrefixedMessageInnerMessage2Input$Shape
-> = builder.inputRef<PrefixedMessageInnerMessage2Input$Shape>(
-  "PrefixedMessageInnerMessage2Input",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-      name: "InnerMessage2",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const PrefixedMessageInnerMessage2Input$Ref: InputObjectRef<PrefixedMessageInnerMessage2Input$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessage2Input$Shape>(
+      "PrefixedMessageInnerMessage2Input",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+          name: "InnerMessage2",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export function PrefixedMessageInnerMessage2Input$toProto(
   input: PrefixedMessageInnerMessage2Input$Shape | null | undefined,
@@ -640,45 +656,46 @@ export type PrefixedMessageSquashedMessageInput$Shape = {
   oneofField2?: PrefixedMessageInnerMessage2Input$Shape | null;
 };
 
-export const PrefixedMessageSquashedMessageInput$Ref: InputObjectRef<
-  PrefixedMessageSquashedMessageInput$Shape
-> = builder.inputRef<PrefixedMessageSquashedMessageInput$Shape>(
-  "PrefixedMessageSquashedMessageInput",
-).implement({
-  fields: (t) => ({
-    oneofField: t.field({
-      type: PrefixedMessageInnerMessageInput$Ref,
-      required: false,
+export const PrefixedMessageSquashedMessageInput$Ref: InputObjectRef<PrefixedMessageSquashedMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageSquashedMessageInput$Shape>(
+      "PrefixedMessageSquashedMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        oneofField: t.field({
+          type: PrefixedMessageInnerMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
+          },
+        }),
+        oneofField2: t.field({
+          type: PrefixedMessageInnerMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field_2",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "oneof_field",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+          name: "SquashedMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { squashUnion: true } },
         },
       },
-    }),
-    oneofField2: t.field({
-      type: PrefixedMessageInnerMessage2Input$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "oneof_field_2",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
-      name: "SquashedMessage",
-      package: "testapis.options.message_and_field",
-      options: { "[graphql.object_type]": { squashUnion: true } },
-    },
-  },
-});
+    });
 
 export function PrefixedMessageSquashedMessageInput$toProto(
   input: PrefixedMessageSquashedMessageInput$Shape | null | undefined,
@@ -686,15 +703,15 @@ export function PrefixedMessageSquashedMessageInput$toProto(
   return new PrefixedMessage_SquashedMessage({
     squashedMessage: input?.oneofField
       ? {
-        case: "oneofField",
-        value: PrefixedMessageInnerMessageInput$toProto(input.oneofField),
-      }
+          case: "oneofField",
+          value: PrefixedMessageInnerMessageInput$toProto(input.oneofField),
+        }
       : input?.oneofField2
-      ? {
-        case: "oneofField2",
-        value: PrefixedMessageInnerMessage2Input$toProto(input.oneofField2),
-      }
-      : undefined,
+        ? {
+            case: "oneofField2",
+            value: PrefixedMessageInnerMessage2Input$toProto(input.oneofField2),
+          }
+        : undefined,
   });
 }
 
@@ -702,36 +719,41 @@ export type IgnoredMessageNotIgnoredInput$Shape = {
   body: IgnoredMessage_NotIgnored["body"];
 };
 
-export const IgnoredMessageNotIgnoredInput$Ref: InputObjectRef<
-  IgnoredMessageNotIgnoredInput$Shape
-> = builder.inputRef<IgnoredMessageNotIgnoredInput$Shape>(
-  "IgnoredMessageNotIgnoredInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
-      name: "NotIgnored",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const IgnoredMessageNotIgnoredInput$Ref: InputObjectRef<IgnoredMessageNotIgnoredInput$Shape> =
+  builder
+    .inputRef<IgnoredMessageNotIgnoredInput$Shape>(
+      "IgnoredMessageNotIgnoredInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+          name: "NotIgnored",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export function IgnoredMessageNotIgnoredInput$toProto(
   input: IgnoredMessageNotIgnoredInput$Shape | null | undefined,
 ): IgnoredMessage_NotIgnored {
-  return new IgnoredMessage_NotIgnored({ body: input?.body ?? undefined });
+  return new IgnoredMessage_NotIgnored({
+    body: input?.body ?? undefined,
+  });
 }
 
-export const InterfaceMessage$Ref = builder.interfaceRef<
-  Pick<InterfaceMessage, "id">
->("InterfaceMessage");
+export const InterfaceMessage$Ref =
+  builder.interfaceRef<Pick<InterfaceMessage, "id">>("InterfaceMessage");
 builder.interfaceType(InterfaceMessage$Ref, {
   name: "InterfaceMessage",
   fields: (t) => ({
@@ -761,17 +783,18 @@ export const PrefixedMessageSquashedMessage$Ref = builder.unionType(
           "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
         name: "SquashedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }, {
-          name: "oneof_field_2",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }],
+        fields: [
+          {
+            name: "oneof_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+          {
+            name: "oneof_field_2",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+        ],
       },
     },
   },
@@ -788,18 +811,19 @@ export const PrefixedMessagePartialIgnoreOneof$Ref = builder.unionType(
         name: "partial_ignore_oneof",
         messageName: "PrefixedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_not_ignored_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-        }],
+        fields: [
+          {
+            name: "oneof_not_ignored_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+          },
+        ],
       },
     },
   },
 );
 
-export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> = builder
-  .enumType("RenamedEnum", {
+export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> =
+  builder.enumType("RenamedEnum", {
     values: {
       FOO: {
         value: 1,
@@ -820,8 +844,8 @@ export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> = builder
     },
   });
 
-export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> = builder
-  .enumType("PrefixedEnum", {
+export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> =
+  builder.enumType("PrefixedEnum", {
     values: {
       PREFIXED_FOO: {
         value: 1,

--- a/tests/golden/protobuf-es-v1/testapis.options.schema/__expected__/testapis/options/schema/schema.pb.pothos.ts
+++ b/tests/golden/protobuf-es-v1/testapis.options.schema/__expected__/testapis/options/schema/schema.pb.pothos.ts
@@ -40,31 +40,34 @@ export type SchemaPrefixPostResponseInput$Shape = {
   body: PostResponse["body"];
 };
 
-export const SchemaPrefixPostResponseInput$Ref: InputObjectRef<
-  SchemaPrefixPostResponseInput$Shape
-> = builder.inputRef<SchemaPrefixPostResponseInput$Shape>(
-  "SchemaPrefixPostResponseInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.schema.PostResponse",
-      name: "PostResponse",
-      package: "testapis.options.schema",
-    },
-  },
-});
+export const SchemaPrefixPostResponseInput$Ref: InputObjectRef<SchemaPrefixPostResponseInput$Shape> =
+  builder
+    .inputRef<SchemaPrefixPostResponseInput$Shape>(
+      "SchemaPrefixPostResponseInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.schema.PostResponse",
+          name: "PostResponse",
+          package: "testapis.options.schema",
+        },
+      },
+    });
 
 export function SchemaPrefixPostResponseInput$toProto(
   input: SchemaPrefixPostResponseInput$Shape | null | undefined,

--- a/tests/golden/protobuf-es/testapis.basic.empty/__expected__/testapis/basic/empty/empty.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.basic.empty/__expected__/testapis/basic/empty/empty.pb.pothos.ts
@@ -10,9 +10,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/basic/empty/empty_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const EmptyMessage$Ref = builder.objectRef<
-  MessageShape<typeof EmptyMessageSchema>
->("EmptyMessage");
+export const EmptyMessage$Ref =
+  builder.objectRef<MessageShape<typeof EmptyMessageSchema>>("EmptyMessage");
 builder.objectType(EmptyMessage$Ref, {
   name: "EmptyMessage",
   fields: (t) => ({

--- a/tests/golden/protobuf-es/testapis.basic.enums/__expected__/testapis/basic/enums/enums.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.basic.enums/__expected__/testapis/basic/enums/enums.pb.pothos.ts
@@ -12,9 +12,10 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/basic/enums/enums_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const MessageWithEnums$Ref = builder.objectRef<
-  MessageShape<typeof MessageWithEnumsSchema>
->("MessageWithEnums");
+export const MessageWithEnums$Ref =
+  builder.objectRef<MessageShape<typeof MessageWithEnumsSchema>>(
+    "MessageWithEnums",
+  );
 builder.objectType(MessageWithEnums$Ref, {
   name: "MessageWithEnums",
   fields: (t) => ({
@@ -172,122 +173,120 @@ builder.objectType(MessageWithEnums$Ref, {
 export type MessageWithEnumsInput$Shape = {
   requiredMyEnum: MessageWithEnums["requiredMyEnum"];
   optionalMyEnum?: MessageWithEnums["optionalMyEnum"] | null;
-  requiredMyEnumWithoutUnspecified:
-    MessageWithEnums["requiredMyEnumWithoutUnspecified"];
+  requiredMyEnumWithoutUnspecified: MessageWithEnums["requiredMyEnumWithoutUnspecified"];
   optionalMyEnumWithoutUnspecified?:
     | MessageWithEnums["optionalMyEnumWithoutUnspecified"]
     | null;
   requiredMyEnums: MessageWithEnums["requiredMyEnums"];
   optionalMyEnums?: MessageWithEnums["optionalMyEnums"] | null;
-  requiredMyEnumWithoutUnspecifieds:
-    MessageWithEnums["requiredMyEnumWithoutUnspecifieds"];
+  requiredMyEnumWithoutUnspecifieds: MessageWithEnums["requiredMyEnumWithoutUnspecifieds"];
   optionalMyEnumWithoutUnspecifieds?:
     | MessageWithEnums["optionalMyEnumWithoutUnspecifieds"]
     | null;
 };
 
-export const MessageWithEnumsInput$Ref: InputObjectRef<
-  MessageWithEnumsInput$Shape
-> = builder.inputRef<MessageWithEnumsInput$Shape>("MessageWithEnumsInput")
-  .implement({
-    fields: (t) => ({
-      requiredMyEnum: t.field({
-        type: MyEnum$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enum",
-            typeFullName: "testapis.basic.enums.MyEnum",
+export const MessageWithEnumsInput$Ref: InputObjectRef<MessageWithEnumsInput$Shape> =
+  builder
+    .inputRef<MessageWithEnumsInput$Shape>("MessageWithEnumsInput")
+    .implement({
+      fields: (t) => ({
+        requiredMyEnum: t.field({
+          type: MyEnum$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enum",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      optionalMyEnum: t.field({
-        type: MyEnum$Ref,
-        required: false,
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enum",
-            typeFullName: "testapis.basic.enums.MyEnum",
+        }),
+        optionalMyEnum: t.field({
+          type: MyEnum$Ref,
+          required: false,
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enum",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      requiredMyEnumWithoutUnspecified: t.field({
-        type: MyEnumWithoutUnspecified$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enum_without_unspecified",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        requiredMyEnumWithoutUnspecified: t.field({
+          type: MyEnumWithoutUnspecified$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enum_without_unspecified",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
-      }),
-      optionalMyEnumWithoutUnspecified: t.field({
-        type: MyEnumWithoutUnspecified$Ref,
-        required: false,
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enum_without_unspecified",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        optionalMyEnumWithoutUnspecified: t.field({
+          type: MyEnumWithoutUnspecified$Ref,
+          required: false,
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enum_without_unspecified",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
-      }),
-      requiredMyEnums: t.field({
-        type: [MyEnum$Ref],
-        required: { list: true, items: true },
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enums",
-            typeFullName: "testapis.basic.enums.MyEnum",
+        }),
+        requiredMyEnums: t.field({
+          type: [MyEnum$Ref],
+          required: { list: true, items: true },
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enums",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      optionalMyEnums: t.field({
-        type: [MyEnum$Ref],
-        required: { list: false, items: true },
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enums",
-            typeFullName: "testapis.basic.enums.MyEnum",
+        }),
+        optionalMyEnums: t.field({
+          type: [MyEnum$Ref],
+          required: { list: false, items: true },
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enums",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      requiredMyEnumWithoutUnspecifieds: t.field({
-        type: [MyEnumWithoutUnspecified$Ref],
-        required: { list: true, items: true },
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enum_without_unspecifieds",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        requiredMyEnumWithoutUnspecifieds: t.field({
+          type: [MyEnumWithoutUnspecified$Ref],
+          required: { list: true, items: true },
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enum_without_unspecifieds",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
-      }),
-      optionalMyEnumWithoutUnspecifieds: t.field({
-        type: [MyEnumWithoutUnspecified$Ref],
-        required: { list: false, items: true },
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enum_without_unspecifieds",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        optionalMyEnumWithoutUnspecifieds: t.field({
+          type: [MyEnumWithoutUnspecified$Ref],
+          required: { list: false, items: true },
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enum_without_unspecifieds",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.enums.MessageWithEnums",
-        name: "MessageWithEnums",
-        package: "testapis.basic.enums",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.enums.MessageWithEnums",
+          name: "MessageWithEnums",
+          package: "testapis.basic.enums",
+        },
       },
-    },
-  }) as InputObjectRef<MessageWithEnumsInput$Shape>;
+    }) as InputObjectRef<MessageWithEnumsInput$Shape>;
 
 export function MessageWithEnumsInput$toProto(
   input: MessageWithEnumsInput$Shape | null | undefined,
@@ -295,10 +294,10 @@ export function MessageWithEnumsInput$toProto(
   return create(MessageWithEnumsSchema, {
     requiredMyEnum: input?.requiredMyEnum ?? undefined,
     optionalMyEnum: input?.optionalMyEnum ?? undefined,
-    requiredMyEnumWithoutUnspecified: input?.requiredMyEnumWithoutUnspecified ??
-      undefined,
-    optionalMyEnumWithoutUnspecified: input?.optionalMyEnumWithoutUnspecified ??
-      undefined,
+    requiredMyEnumWithoutUnspecified:
+      input?.requiredMyEnumWithoutUnspecified ?? undefined,
+    optionalMyEnumWithoutUnspecified:
+      input?.optionalMyEnumWithoutUnspecified ?? undefined,
     requiredMyEnums: input?.requiredMyEnums ?? undefined,
     optionalMyEnums: input?.optionalMyEnums ?? undefined,
     requiredMyEnumWithoutUnspecifieds:

--- a/tests/golden/protobuf-es/testapis.basic.nested/__expected__/testapis/basic/nested/nested.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.basic.nested/__expected__/testapis/basic/nested/nested.pb.pothos.ts
@@ -13,9 +13,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/basic/nested/nested_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const ParentMessage$Ref = builder.objectRef<
-  MessageShape<typeof ParentMessageSchema>
->("ParentMessage");
+export const ParentMessage$Ref =
+  builder.objectRef<MessageShape<typeof ParentMessageSchema>>("ParentMessage");
 builder.objectType(ParentMessage$Ref, {
   name: "ParentMessage",
   fields: (t) => ({
@@ -99,42 +98,46 @@ export type ParentMessageInput$Shape = {
 };
 
 export const ParentMessageInput$Ref: InputObjectRef<ParentMessageInput$Shape> =
-  builder.inputRef<ParentMessageInput$Shape>("ParentMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      nested: t.field({
-        type: ParentMessageNestedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "nested",
-            typeFullName: "testapis.basic.nested.ParentMessage.NestedMessage",
+  builder
+    .inputRef<ParentMessageInput$Shape>("ParentMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
-      }),
-      nestedEnum: t.field({
-        type: ParentMessageNestedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "nested_enum",
-            typeFullName: "testapis.basic.nested.ParentMessage.NestedEnum",
+        }),
+        nested: t.field({
+          type: ParentMessageNestedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "nested",
+              typeFullName: "testapis.basic.nested.ParentMessage.NestedMessage",
+            },
           },
-        },
+        }),
+        nestedEnum: t.field({
+          type: ParentMessageNestedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "nested_enum",
+              typeFullName: "testapis.basic.nested.ParentMessage.NestedEnum",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.nested.ParentMessage",
-        name: "ParentMessage",
-        package: "testapis.basic.nested",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.nested.ParentMessage",
+          name: "ParentMessage",
+          package: "testapis.basic.nested",
+        },
       },
-    },
-  }) as InputObjectRef<ParentMessageInput$Shape>;
+    }) as InputObjectRef<ParentMessageInput$Shape>;
 
 export function ParentMessageInput$toProto(
   input: ParentMessageInput$Shape | null | undefined,
@@ -152,28 +155,29 @@ export type ParentMessageNestedMessageInput$Shape = {
   nestedBody: ParentMessage_NestedMessage["nestedBody"];
 };
 
-export const ParentMessageNestedMessageInput$Ref: InputObjectRef<
-  ParentMessageNestedMessageInput$Shape
-> = builder.inputRef<ParentMessageNestedMessageInput$Shape>(
-  "ParentMessageNestedMessageInput",
-).implement({
-  fields: (t) => ({
-    nestedBody: t.field({
-      type: "String",
-      required: true,
+export const ParentMessageNestedMessageInput$Ref: InputObjectRef<ParentMessageNestedMessageInput$Shape> =
+  builder
+    .inputRef<ParentMessageNestedMessageInput$Shape>(
+      "ParentMessageNestedMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        nestedBody: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "nested_body", typeFullName: "string" },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: { name: "nested_body", typeFullName: "string" },
+        protobufMessage: {
+          fullName: "testapis.basic.nested.ParentMessage.NestedMessage",
+          name: "NestedMessage",
+          package: "testapis.basic.nested",
+        },
       },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.basic.nested.ParentMessage.NestedMessage",
-      name: "NestedMessage",
-      package: "testapis.basic.nested",
-    },
-  },
-}) as InputObjectRef<ParentMessageNestedMessageInput$Shape>;
+    }) as InputObjectRef<ParentMessageNestedMessageInput$Shape>;
 
 export function ParentMessageNestedMessageInput$toProto(
   input: ParentMessageNestedMessageInput$Shape | null | undefined,

--- a/tests/golden/protobuf-es/testapis.basic.presence/__expected__/testapis/basic/presence/presence.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.basic.presence/__expected__/testapis/basic/presence/presence.pb.pothos.ts
@@ -12,9 +12,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/basic/presence/presence_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const Message$Ref = builder.objectRef<
-  MessageShape<typeof MessageSchema>
->("Message");
+export const Message$Ref =
+  builder.objectRef<MessageShape<typeof MessageSchema>>("Message");
 builder.objectType(Message$Ref, {
   name: "Message",
   fields: (t) => ({
@@ -61,9 +60,8 @@ builder.objectType(Message$Ref, {
   },
 });
 
-export const NestedMessage$Ref = builder.objectRef<
-  MessageShape<typeof NestedMessageSchema>
->("NestedMessage");
+export const NestedMessage$Ref =
+  builder.objectRef<MessageShape<typeof NestedMessageSchema>>("NestedMessage");
 builder.objectType(NestedMessage$Ref, {
   name: "NestedMessage",
   fields: (t) => ({
@@ -92,7 +90,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredStringValue: t.field({
         type: "String",
@@ -146,28 +145,36 @@ export function MessageInput$toProto(
   });
 }
 
-export type NestedMessageInput$Shape = { body: NestedMessage["body"]; };
+export type NestedMessageInput$Shape = {
+  body: NestedMessage["body"];
+};
 
 export const NestedMessageInput$Ref: InputObjectRef<NestedMessageInput$Shape> =
-  builder.inputRef<NestedMessageInput$Shape>("NestedMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<NestedMessageInput$Shape>("NestedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.presence.NestedMessage",
-        name: "NestedMessage",
-        package: "testapis.basic.presence",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.presence.NestedMessage",
+          name: "NestedMessage",
+          package: "testapis.basic.presence",
+        },
       },
-    },
-  }) as InputObjectRef<NestedMessageInput$Shape>;
+    }) as InputObjectRef<NestedMessageInput$Shape>;
 
 export function NestedMessageInput$toProto(
   input: NestedMessageInput$Shape | null | undefined,
 ): NestedMessage {
-  return create(NestedMessageSchema, { body: input?.body ?? undefined });
+  return create(NestedMessageSchema, {
+    body: input?.body ?? undefined,
+  });
 }

--- a/tests/golden/protobuf-es/testapis.basic.scalars/__expected__/testapis/basic/scalars/scalars.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.basic.scalars/__expected__/testapis/basic/scalars/scalars.pb.pothos.ts
@@ -12,9 +12,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/basic/scalars/scalars_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const Message$Ref = builder.objectRef<
-  MessageShape<typeof MessageSchema>
->("Message");
+export const Message$Ref =
+  builder.objectRef<MessageShape<typeof MessageSchema>>("Message");
 builder.objectType(Message$Ref, {
   name: "Message",
   fields: (t) => ({
@@ -81,9 +80,8 @@ builder.objectType(Message$Ref, {
   },
 });
 
-export const Primitives$Ref = builder.objectRef<
-  MessageShape<typeof PrimitivesSchema>
->("Primitives");
+export const Primitives$Ref =
+  builder.objectRef<MessageShape<typeof PrimitivesSchema>>("Primitives");
 builder.objectType(Primitives$Ref, {
   name: "Primitives",
   fields: (t) => ({
@@ -384,7 +382,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredPrimitives: t.field({
         type: PrimitivesInput$Ref,
@@ -451,10 +450,10 @@ export function MessageInput$toProto(
       ? PrimitivesInput$toProto(input.optionalPrimitives)
       : undefined,
     requiredPrimitivesList: input?.requiredPrimitivesList?.map((v) =>
-      PrimitivesInput$toProto(v)
+      PrimitivesInput$toProto(v),
     ),
     optionalPrimitivesList: input?.optionalPrimitivesList?.map((v) =>
-      PrimitivesInput$toProto(v)
+      PrimitivesInput$toProto(v),
     ),
   });
 }
@@ -493,311 +492,319 @@ export type PrimitivesInput$Shape = {
 };
 
 export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
-  builder.inputRef<PrimitivesInput$Shape>("PrimitivesInput").implement({
-    fields: (t) => ({
-      requiredDoubleValue: t.field({
-        type: "Float",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_double_value",
-            typeFullName: "double",
+  builder
+    .inputRef<PrimitivesInput$Shape>("PrimitivesInput")
+    .implement({
+      fields: (t) => ({
+        requiredDoubleValue: t.field({
+          type: "Float",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_double_value",
+              typeFullName: "double",
+            },
           },
-        },
-      }),
-      requiredFloatValue: t.field({
-        type: "Float",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_float_value",
-            typeFullName: "float",
+        }),
+        requiredFloatValue: t.field({
+          type: "Float",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_float_value",
+              typeFullName: "float",
+            },
           },
-        },
-      }),
-      requiredInt32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_int32_value",
-            typeFullName: "int32",
+        }),
+        requiredInt32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_int32_value",
+              typeFullName: "int32",
+            },
           },
-        },
-      }),
-      requiredInt64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_int64_value",
-            typeFullName: "int64",
+        }),
+        requiredInt64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_int64_value",
+              typeFullName: "int64",
+            },
           },
-        },
-      }),
-      requiredUint32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_uint32_value",
-            typeFullName: "uint32",
+        }),
+        requiredUint32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_uint32_value",
+              typeFullName: "uint32",
+            },
           },
-        },
-      }),
-      requiredUint64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_uint64_value",
-            typeFullName: "uint64",
+        }),
+        requiredUint64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_uint64_value",
+              typeFullName: "uint64",
+            },
           },
-        },
-      }),
-      requiredSint32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sint32_value",
-            typeFullName: "sint32",
+        }),
+        requiredSint32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sint32_value",
+              typeFullName: "sint32",
+            },
           },
-        },
-      }),
-      requiredSint64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sint64_value",
-            typeFullName: "sint64",
+        }),
+        requiredSint64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sint64_value",
+              typeFullName: "sint64",
+            },
           },
-        },
-      }),
-      requiredFixed32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_fixed32_value",
-            typeFullName: "fixed32",
+        }),
+        requiredFixed32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_fixed32_value",
+              typeFullName: "fixed32",
+            },
           },
-        },
-      }),
-      requiredFixed64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_fixed64_value",
-            typeFullName: "fixed64",
+        }),
+        requiredFixed64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_fixed64_value",
+              typeFullName: "fixed64",
+            },
           },
-        },
-      }),
-      requiredSfixed32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sfixed32_value",
-            typeFullName: "sfixed32",
+        }),
+        requiredSfixed32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sfixed32_value",
+              typeFullName: "sfixed32",
+            },
           },
-        },
-      }),
-      requiredSfixed64Value: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sfixed64_value",
-            typeFullName: "sfixed64",
+        }),
+        requiredSfixed64Value: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sfixed64_value",
+              typeFullName: "sfixed64",
+            },
           },
-        },
-      }),
-      requiredBoolValue: t.field({
-        type: "Boolean",
-        required: true,
-        extensions: {
-          protobufField: { name: "required_bool_value", typeFullName: "bool" },
-        },
-      }),
-      requiredStringValue: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_string_value",
-            typeFullName: "string",
+        }),
+        requiredBoolValue: t.field({
+          type: "Boolean",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_bool_value",
+              typeFullName: "bool",
+            },
           },
-        },
-      }),
-      requiredBytesValue: t.field({
-        type: "Byte",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_bytes_value",
-            typeFullName: "bytes",
+        }),
+        requiredStringValue: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_string_value",
+              typeFullName: "string",
+            },
           },
-        },
-      }),
-      requiredDoubleValues: t.field({
-        type: ["Float"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_double_values",
-            typeFullName: "double",
+        }),
+        requiredBytesValue: t.field({
+          type: "Byte",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_bytes_value",
+              typeFullName: "bytes",
+            },
           },
-        },
-      }),
-      requiredFloatValues: t.field({
-        type: ["Float"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_float_values",
-            typeFullName: "float",
+        }),
+        requiredDoubleValues: t.field({
+          type: ["Float"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_double_values",
+              typeFullName: "double",
+            },
           },
-        },
-      }),
-      requiredInt32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_int32_values",
-            typeFullName: "int32",
+        }),
+        requiredFloatValues: t.field({
+          type: ["Float"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_float_values",
+              typeFullName: "float",
+            },
           },
-        },
-      }),
-      requiredInt64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_int64_values",
-            typeFullName: "int64",
+        }),
+        requiredInt32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_int32_values",
+              typeFullName: "int32",
+            },
           },
-        },
-      }),
-      requiredUint32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_uint32_values",
-            typeFullName: "uint32",
+        }),
+        requiredInt64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_int64_values",
+              typeFullName: "int64",
+            },
           },
-        },
-      }),
-      requiredUint64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_uint64_values",
-            typeFullName: "uint64",
+        }),
+        requiredUint32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_uint32_values",
+              typeFullName: "uint32",
+            },
           },
-        },
-      }),
-      requiredSint32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sint32_values",
-            typeFullName: "sint32",
+        }),
+        requiredUint64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_uint64_values",
+              typeFullName: "uint64",
+            },
           },
-        },
-      }),
-      requiredSint64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sint64_values",
-            typeFullName: "sint64",
+        }),
+        requiredSint32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sint32_values",
+              typeFullName: "sint32",
+            },
           },
-        },
-      }),
-      requiredFixed32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_fixed32_values",
-            typeFullName: "fixed32",
+        }),
+        requiredSint64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sint64_values",
+              typeFullName: "sint64",
+            },
           },
-        },
-      }),
-      requiredFixed64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_fixed64_values",
-            typeFullName: "fixed64",
+        }),
+        requiredFixed32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_fixed32_values",
+              typeFullName: "fixed32",
+            },
           },
-        },
-      }),
-      requiredSfixed32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sfixed32_values",
-            typeFullName: "sfixed32",
+        }),
+        requiredFixed64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_fixed64_values",
+              typeFullName: "fixed64",
+            },
           },
-        },
-      }),
-      requiredSfixed64Values: t.field({
-        type: ["Int64"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sfixed64_values",
-            typeFullName: "sfixed64",
+        }),
+        requiredSfixed32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sfixed32_values",
+              typeFullName: "sfixed32",
+            },
           },
-        },
-      }),
-      requiredBoolValues: t.field({
-        type: ["Boolean"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: { name: "required_bool_values", typeFullName: "bool" },
-        },
-      }),
-      requiredStringValues: t.field({
-        type: ["String"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_string_values",
-            typeFullName: "string",
+        }),
+        requiredSfixed64Values: t.field({
+          type: ["Int64"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sfixed64_values",
+              typeFullName: "sfixed64",
+            },
           },
-        },
-      }),
-      requiredBytesValues: t.field({
-        type: ["Byte"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_bytes_values",
-            typeFullName: "bytes",
+        }),
+        requiredBoolValues: t.field({
+          type: ["Boolean"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_bool_values",
+              typeFullName: "bool",
+            },
           },
-        },
+        }),
+        requiredStringValues: t.field({
+          type: ["String"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_string_values",
+              typeFullName: "string",
+            },
+          },
+        }),
+        requiredBytesValues: t.field({
+          type: ["Byte"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_bytes_values",
+              typeFullName: "bytes",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.scalars.Primitives",
-        name: "Primitives",
-        package: "testapis.basic.scalars",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.scalars.Primitives",
+          name: "Primitives",
+          package: "testapis.basic.scalars",
+        },
       },
-    },
-  }) as InputObjectRef<PrimitivesInput$Shape>;
+    }) as InputObjectRef<PrimitivesInput$Shape>;
 
 export function PrimitivesInput$toProto(
   input: PrimitivesInput$Shape | null | undefined,

--- a/tests/golden/protobuf-es/testapis.basic.schema_name_collision/__expected__/testapis/basic/schema_name_collision/schema_name_collision.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.basic.schema_name_collision/__expected__/testapis/basic/schema_name_collision/schema_name_collision.pb.pothos.ts
@@ -12,9 +12,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/basic/schema_name_collision/schema_name_collision_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const Foo$Ref = builder.objectRef<MessageShape<typeof FooSchema$>>(
-  "Foo",
-);
+export const Foo$Ref =
+  builder.objectRef<MessageShape<typeof FooSchema$>>("Foo");
 builder.objectType(Foo$Ref, {
   name: "Foo",
   fields: (t) => ({
@@ -36,9 +35,8 @@ builder.objectType(Foo$Ref, {
   },
 });
 
-export const FooSchema$Ref = builder.objectRef<
-  MessageShape<typeof FooSchemaSchema>
->("FooSchema");
+export const FooSchema$Ref =
+  builder.objectRef<MessageShape<typeof FooSchemaSchema>>("FooSchema");
 builder.objectType(FooSchema$Ref, {
   name: "FooSchema",
   fields: (t) => ({
@@ -60,37 +58,44 @@ builder.objectType(FooSchema$Ref, {
   },
 });
 
-export type FooInput$Shape = { name: Foo["name"]; };
+export type FooInput$Shape = {
+  name: Foo["name"];
+};
 
-export const FooInput$Ref: InputObjectRef<FooInput$Shape> = builder.inputRef<
-  FooInput$Shape
->("FooInput").implement({
-  fields: (t) => ({
-    name: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "name", typeFullName: "string" } },
+export const FooInput$Ref: InputObjectRef<FooInput$Shape> = builder
+  .inputRef<FooInput$Shape>("FooInput")
+  .implement({
+    fields: (t) => ({
+      name: t.field({
+        type: "String",
+        required: true,
+        extensions: { protobufField: { name: "name", typeFullName: "string" } },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.basic.schema_name_collision.Foo",
-      name: "Foo",
-      package: "testapis.basic.schema_name_collision",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.basic.schema_name_collision.Foo",
+        name: "Foo",
+        package: "testapis.basic.schema_name_collision",
+      },
     },
-  },
-}) as InputObjectRef<FooInput$Shape>;
+  }) as InputObjectRef<FooInput$Shape>;
 
 export function FooInput$toProto(
   input: FooInput$Shape | null | undefined,
 ): Foo {
-  return create(FooSchema$, { name: input?.name ?? undefined });
+  return create(FooSchema$, {
+    name: input?.name ?? undefined,
+  });
 }
 
-export type FooSchemaInput$Shape = { value: FooSchema["value"]; };
+export type FooSchemaInput$Shape = {
+  value: FooSchema["value"];
+};
 
 export const FooSchemaInput$Ref: InputObjectRef<FooSchemaInput$Shape> = builder
-  .inputRef<FooSchemaInput$Shape>("FooSchemaInput").implement({
+  .inputRef<FooSchemaInput$Shape>("FooSchemaInput")
+  .implement({
     fields: (t) => ({
       value: t.field({
         type: "String",
@@ -112,5 +117,7 @@ export const FooSchemaInput$Ref: InputObjectRef<FooSchemaInput$Shape> = builder
 export function FooSchemaInput$toProto(
   input: FooSchemaInput$Shape | null | undefined,
 ): FooSchema {
-  return create(FooSchemaSchema, { value: input?.value ?? undefined });
+  return create(FooSchemaSchema, {
+    value: input?.value ?? undefined,
+  });
 }

--- a/tests/golden/protobuf-es/testapis.basic.wktypes/__expected__/testapis/basic/wktypes/wktypes.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.basic.wktypes/__expected__/testapis/basic/wktypes/wktypes.pb.pothos.ts
@@ -10,9 +10,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/basic/wktypes/wktypes_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const Message$Ref = builder.objectRef<
-  MessageShape<typeof MessageSchema>
->("Message");
+export const Message$Ref =
+  builder.objectRef<MessageShape<typeof MessageSchema>>("Message");
 builder.objectType(Message$Ref, {
   name: "Message",
   fields: (t) => ({
@@ -163,7 +162,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       timestamp: t.field({
         type: "DateTime",

--- a/tests/golden/protobuf-es/testapis.behavior.field_comments/__expected__/testapis/behavior/field_comments/field_comments.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.behavior.field_comments/__expected__/testapis/behavior/field_comments/field_comments.pb.pothos.ts
@@ -120,69 +120,71 @@ export type FieldBehaviorCommentsMessageInput$Shape = {
   inputOnlyField?: FieldBehaviorCommentsMessagePostInput$Shape | null;
 };
 
-export const FieldBehaviorCommentsMessageInput$Ref: InputObjectRef<
-  FieldBehaviorCommentsMessageInput$Shape
-> = builder.inputRef<FieldBehaviorCommentsMessageInput$Shape>(
-  "FieldBehaviorCommentsMessageInput",
-).implement({
-  fields: (t) => ({
-    requiredField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: true,
-      description: "Required.",
+export const FieldBehaviorCommentsMessageInput$Ref: InputObjectRef<FieldBehaviorCommentsMessageInput$Shape> =
+  builder
+    .inputRef<FieldBehaviorCommentsMessageInput$Shape>(
+      "FieldBehaviorCommentsMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        requiredField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+        requiredInputOnlyField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: true,
+          description: "Required. Input only.",
+          extensions: {
+            protobufField: {
+              name: "required_input_only_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+        inputOnlyRequiredField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: true,
+          description: "Input only. Required.",
+          extensions: {
+            protobufField: {
+              name: "input_only_required_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+        inputOnlyField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: false,
+          description: "Input only.",
+          extensions: {
+            protobufField: {
+              name: "input_only_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "required_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+        protobufMessage: {
+          fullName:
+            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage",
+          name: "FieldBehaviorCommentsMessage",
+          package: "testapis.behavior.field_comments",
         },
       },
-    }),
-    requiredInputOnlyField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: true,
-      description: "Required. Input only.",
-      extensions: {
-        protobufField: {
-          name: "required_input_only_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-        },
-      },
-    }),
-    inputOnlyRequiredField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: true,
-      description: "Input only. Required.",
-      extensions: {
-        protobufField: {
-          name: "input_only_required_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-        },
-      },
-    }),
-    inputOnlyField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: false,
-      description: "Input only.",
-      extensions: {
-        protobufField: {
-          name: "input_only_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.behavior.field_comments.FieldBehaviorCommentsMessage",
-      name: "FieldBehaviorCommentsMessage",
-      package: "testapis.behavior.field_comments",
-    },
-  },
-}) as InputObjectRef<FieldBehaviorCommentsMessageInput$Shape>;
+    }) as InputObjectRef<FieldBehaviorCommentsMessageInput$Shape>;
 
 export function FieldBehaviorCommentsMessageInput$toProto(
   input: FieldBehaviorCommentsMessageInput$Shape | null | undefined,
@@ -193,13 +195,13 @@ export function FieldBehaviorCommentsMessageInput$toProto(
       : undefined,
     requiredInputOnlyField: input?.requiredInputOnlyField
       ? FieldBehaviorCommentsMessagePostInput$toProto(
-        input.requiredInputOnlyField,
-      )
+          input.requiredInputOnlyField,
+        )
       : undefined,
     inputOnlyRequiredField: input?.inputOnlyRequiredField
       ? FieldBehaviorCommentsMessagePostInput$toProto(
-        input.inputOnlyRequiredField,
-      )
+          input.inputOnlyRequiredField,
+        )
       : undefined,
     inputOnlyField: input?.inputOnlyField
       ? FieldBehaviorCommentsMessagePostInput$toProto(input.inputOnlyField)
@@ -211,27 +213,30 @@ export type FieldBehaviorCommentsMessagePostInput$Shape = {
   body: FieldBehaviorCommentsMessage_Post["body"];
 };
 
-export const FieldBehaviorCommentsMessagePostInput$Ref: InputObjectRef<
-  FieldBehaviorCommentsMessagePostInput$Shape
-> = builder.inputRef<FieldBehaviorCommentsMessagePostInput$Shape>(
-  "FieldBehaviorCommentsMessagePostInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-      name: "Post",
-      package: "testapis.behavior.field_comments",
-    },
-  },
-}) as InputObjectRef<FieldBehaviorCommentsMessagePostInput$Shape>;
+export const FieldBehaviorCommentsMessagePostInput$Ref: InputObjectRef<FieldBehaviorCommentsMessagePostInput$Shape> =
+  builder
+    .inputRef<FieldBehaviorCommentsMessagePostInput$Shape>(
+      "FieldBehaviorCommentsMessagePostInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+          name: "Post",
+          package: "testapis.behavior.field_comments",
+        },
+      },
+    }) as InputObjectRef<FieldBehaviorCommentsMessagePostInput$Shape>;
 
 export function FieldBehaviorCommentsMessagePostInput$toProto(
   input: FieldBehaviorCommentsMessagePostInput$Shape | null | undefined,

--- a/tests/golden/protobuf-es/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_a/types.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_a/types.pb.pothos.ts
@@ -16,9 +16,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/imports/cross_pkg_a/types_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const BaseMessage$Ref = builder.objectRef<
-  MessageShape<typeof BaseMessageSchema>
->("BaseMessage");
+export const BaseMessage$Ref =
+  builder.objectRef<MessageShape<typeof BaseMessageSchema>>("BaseMessage");
 builder.objectType(BaseMessage$Ref, {
   name: "BaseMessage",
   fields: (t) => ({
@@ -40,9 +39,8 @@ builder.objectType(BaseMessage$Ref, {
   },
 });
 
-export const Parent$Ref = builder.objectRef<MessageShape<typeof ParentSchema>>(
-  "Parent",
-);
+export const Parent$Ref =
+  builder.objectRef<MessageShape<typeof ParentSchema>>("Parent");
 builder.objectType(Parent$Ref, {
   name: "Parent",
   fields: (t) => ({
@@ -65,9 +63,8 @@ builder.objectType(Parent$Ref, {
   },
 });
 
-export const ParentChild$Ref = builder.objectRef<
-  MessageShape<typeof Parent_ChildSchema>
->("ParentChild");
+export const ParentChild$Ref =
+  builder.objectRef<MessageShape<typeof Parent_ChildSchema>>("ParentChild");
 builder.objectType(ParentChild$Ref, {
   name: "ParentChild",
   fields: (t) => ({
@@ -89,36 +86,45 @@ builder.objectType(ParentChild$Ref, {
   },
 });
 
-export type BaseMessageInput$Shape = { body: BaseMessage["body"]; };
+export type BaseMessageInput$Shape = {
+  body: BaseMessage["body"];
+};
 
 export const BaseMessageInput$Ref: InputObjectRef<BaseMessageInput$Shape> =
-  builder.inputRef<BaseMessageInput$Shape>("BaseMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<BaseMessageInput$Shape>("BaseMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.cross_pkg_a.BaseMessage",
-        name: "BaseMessage",
-        package: "testapis.imports.cross_pkg_a",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.cross_pkg_a.BaseMessage",
+          name: "BaseMessage",
+          package: "testapis.imports.cross_pkg_a",
+        },
       },
-    },
-  }) as InputObjectRef<BaseMessageInput$Shape>;
+    }) as InputObjectRef<BaseMessageInput$Shape>;
 
 export function BaseMessageInput$toProto(
   input: BaseMessageInput$Shape | null | undefined,
 ): BaseMessage {
-  return create(BaseMessageSchema, { body: input?.body ?? undefined });
+  return create(BaseMessageSchema, {
+    body: input?.body ?? undefined,
+  });
 }
 
 export type ParentInput$Shape = {};
 
 export const ParentInput$Ref: InputObjectRef<ParentInput$Shape> = builder
-  .inputRef<ParentInput$Shape>("ParentInput").implement({
+  .inputRef<ParentInput$Shape>("ParentInput")
+  .implement({
     fields: (t) => ({
       _: t.field({
         type: "Boolean",
@@ -141,30 +147,38 @@ export function ParentInput$toProto(
   return create(ParentSchema, {});
 }
 
-export type ParentChildInput$Shape = { body: Parent_Child["body"]; };
+export type ParentChildInput$Shape = {
+  body: Parent_Child["body"];
+};
 
 export const ParentChildInput$Ref: InputObjectRef<ParentChildInput$Shape> =
-  builder.inputRef<ParentChildInput$Shape>("ParentChildInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<ParentChildInput$Shape>("ParentChildInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.cross_pkg_a.Parent.Child",
-        name: "Child",
-        package: "testapis.imports.cross_pkg_a",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.cross_pkg_a.Parent.Child",
+          name: "Child",
+          package: "testapis.imports.cross_pkg_a",
+        },
       },
-    },
-  }) as InputObjectRef<ParentChildInput$Shape>;
+    }) as InputObjectRef<ParentChildInput$Shape>;
 
 export function ParentChildInput$toProto(
   input: ParentChildInput$Shape | null | undefined,
 ): Parent_Child {
-  return create(Parent_ChildSchema, { body: input?.body ?? undefined });
+  return create(Parent_ChildSchema, {
+    body: input?.body ?? undefined,
+  });
 }
 
 export const BaseEnum$Ref: EnumRef<BaseEnum, BaseEnum> = builder.enumType(

--- a/tests/golden/protobuf-es/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_b/consumer.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_b/consumer.pb.pothos.ts
@@ -26,9 +26,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/imports/cross_pkg_a/types_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const Consumer$Ref = builder.objectRef<
-  MessageShape<typeof ConsumerSchema>
->("Consumer");
+export const Consumer$Ref =
+  builder.objectRef<MessageShape<typeof ConsumerSchema>>("Consumer");
 builder.objectType(Consumer$Ref, {
   name: "Consumer",
   fields: (t) => ({
@@ -107,7 +106,8 @@ export type ConsumerInput$Shape = {
 };
 
 export const ConsumerInput$Ref: InputObjectRef<ConsumerInput$Shape> = builder
-  .inputRef<ConsumerInput$Shape>("ConsumerInput").implement({
+  .inputRef<ConsumerInput$Shape>("ConsumerInput")
+  .implement({
     fields: (t) => ({
       message: t.field({
         type: BaseMessageInput$Ref,

--- a/tests/golden/protobuf-es/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/member.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/member.pb.pothos.ts
@@ -12,9 +12,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/imports/oneof_cross_file/member_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const OneofMember1$Ref = builder.objectRef<
-  MessageShape<typeof OneofMember1Schema>
->("OneofMember1");
+export const OneofMember1$Ref =
+  builder.objectRef<MessageShape<typeof OneofMember1Schema>>("OneofMember1");
 builder.objectType(OneofMember1$Ref, {
   name: "OneofMember1",
   fields: (t) => ({
@@ -36,9 +35,8 @@ builder.objectType(OneofMember1$Ref, {
   },
 });
 
-export const OneofMember2$Ref = builder.objectRef<
-  MessageShape<typeof OneofMember2Schema>
->("OneofMember2");
+export const OneofMember2$Ref =
+  builder.objectRef<MessageShape<typeof OneofMember2Schema>>("OneofMember2");
 builder.objectType(OneofMember2$Ref, {
   name: "OneofMember2",
   fields: (t) => ({
@@ -60,54 +58,70 @@ builder.objectType(OneofMember2$Ref, {
   },
 });
 
-export type OneofMember1Input$Shape = { body: OneofMember1["body"]; };
+export type OneofMember1Input$Shape = {
+  body: OneofMember1["body"];
+};
 
 export const OneofMember1Input$Ref: InputObjectRef<OneofMember1Input$Shape> =
-  builder.inputRef<OneofMember1Input$Shape>("OneofMember1Input").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<OneofMember1Input$Shape>("OneofMember1Input")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.oneof_cross_file.OneofMember1",
-        name: "OneofMember1",
-        package: "testapis.imports.oneof_cross_file",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.oneof_cross_file.OneofMember1",
+          name: "OneofMember1",
+          package: "testapis.imports.oneof_cross_file",
+        },
       },
-    },
-  }) as InputObjectRef<OneofMember1Input$Shape>;
+    }) as InputObjectRef<OneofMember1Input$Shape>;
 
 export function OneofMember1Input$toProto(
   input: OneofMember1Input$Shape | null | undefined,
 ): OneofMember1 {
-  return create(OneofMember1Schema, { body: input?.body ?? undefined });
+  return create(OneofMember1Schema, {
+    body: input?.body ?? undefined,
+  });
 }
 
-export type OneofMember2Input$Shape = { count: OneofMember2["count"]; };
+export type OneofMember2Input$Shape = {
+  count: OneofMember2["count"];
+};
 
 export const OneofMember2Input$Ref: InputObjectRef<OneofMember2Input$Shape> =
-  builder.inputRef<OneofMember2Input$Shape>("OneofMember2Input").implement({
-    fields: (t) => ({
-      count: t.field({
-        type: "Int",
-        required: true,
-        extensions: { protobufField: { name: "count", typeFullName: "int32" } },
+  builder
+    .inputRef<OneofMember2Input$Shape>("OneofMember2Input")
+    .implement({
+      fields: (t) => ({
+        count: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: { name: "count", typeFullName: "int32" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.oneof_cross_file.OneofMember2",
-        name: "OneofMember2",
-        package: "testapis.imports.oneof_cross_file",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.oneof_cross_file.OneofMember2",
+          name: "OneofMember2",
+          package: "testapis.imports.oneof_cross_file",
+        },
       },
-    },
-  }) as InputObjectRef<OneofMember2Input$Shape>;
+    }) as InputObjectRef<OneofMember2Input$Shape>;
 
 export function OneofMember2Input$toProto(
   input: OneofMember2Input$Shape | null | undefined,
 ): OneofMember2 {
-  return create(OneofMember2Schema, { count: input?.count ?? undefined });
+  return create(OneofMember2Schema, {
+    count: input?.count ?? undefined,
+  });
 }

--- a/tests/golden/protobuf-es/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/parent.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/parent.pb.pothos.ts
@@ -24,9 +24,8 @@ import {
 } from "./member.pb.pothos";
 import { InputObjectRef } from "@pothos/core";
 
-export const OneofParent$Ref = builder.objectRef<
-  MessageShape<typeof OneofParentSchema>
->("OneofParent");
+export const OneofParent$Ref =
+  builder.objectRef<MessageShape<typeof OneofParentSchema>>("OneofParent");
 builder.objectType(OneofParent$Ref, {
   name: "OneofParent",
   fields: (t) => ({
@@ -61,37 +60,39 @@ export type OneofParentInput$Shape = {
 };
 
 export const OneofParentInput$Ref: InputObjectRef<OneofParentInput$Shape> =
-  builder.inputRef<OneofParentInput$Shape>("OneofParentInput").implement({
-    fields: (t) => ({
-      member1: t.field({
-        type: OneofMember1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "member1",
-            typeFullName: "testapis.imports.oneof_cross_file.OneofMember1",
+  builder
+    .inputRef<OneofParentInput$Shape>("OneofParentInput")
+    .implement({
+      fields: (t) => ({
+        member1: t.field({
+          type: OneofMember1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "member1",
+              typeFullName: "testapis.imports.oneof_cross_file.OneofMember1",
+            },
           },
-        },
-      }),
-      member2: t.field({
-        type: OneofMember2Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "member2",
-            typeFullName: "testapis.imports.oneof_cross_file.OneofMember2",
+        }),
+        member2: t.field({
+          type: OneofMember2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "member2",
+              typeFullName: "testapis.imports.oneof_cross_file.OneofMember2",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.oneof_cross_file.OneofParent",
-        name: "OneofParent",
-        package: "testapis.imports.oneof_cross_file",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.oneof_cross_file.OneofParent",
+          name: "OneofParent",
+          package: "testapis.imports.oneof_cross_file",
+        },
       },
-    },
-  }) as InputObjectRef<OneofParentInput$Shape>;
+    }) as InputObjectRef<OneofParentInput$Shape>;
 
 export function OneofParentInput$toProto(
   input: OneofParentInput$Shape | null | undefined,
@@ -100,8 +101,8 @@ export function OneofParentInput$toProto(
     oneofField: input?.member1
       ? { case: "member1", value: OneofMember1Input$toProto(input.member1) }
       : input?.member2
-      ? { case: "member2", value: OneofMember2Input$toProto(input.member2) }
-      : undefined,
+        ? { case: "member2", value: OneofMember2Input$toProto(input.member2) }
+        : undefined,
   });
 }
 
@@ -115,13 +116,16 @@ export const OneofParentOneofField$Ref = builder.unionType(
         name: "oneof_field",
         messageName: "OneofParent",
         package: "testapis.imports.oneof_cross_file",
-        fields: [{
-          name: "member1",
-          type: "testapis.imports.oneof_cross_file.OneofMember1",
-        }, {
-          name: "member2",
-          type: "testapis.imports.oneof_cross_file.OneofMember2",
-        }],
+        fields: [
+          {
+            name: "member1",
+            type: "testapis.imports.oneof_cross_file.OneofMember1",
+          },
+          {
+            name: "member2",
+            type: "testapis.imports.oneof_cross_file.OneofMember2",
+          },
+        ],
       },
     },
   },

--- a/tests/golden/protobuf-es/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/base.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/base.pb.pothos.ts
@@ -11,9 +11,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/imports/same_dir/base_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const SharedMessage$Ref = builder.objectRef<
-  MessageShape<typeof SharedMessageSchema>
->("SharedMessage");
+export const SharedMessage$Ref =
+  builder.objectRef<MessageShape<typeof SharedMessageSchema>>("SharedMessage");
 builder.objectType(SharedMessage$Ref, {
   name: "SharedMessage",
   fields: (t) => ({
@@ -35,30 +34,38 @@ builder.objectType(SharedMessage$Ref, {
   },
 });
 
-export type SharedMessageInput$Shape = { body: SharedMessage["body"]; };
+export type SharedMessageInput$Shape = {
+  body: SharedMessage["body"];
+};
 
 export const SharedMessageInput$Ref: InputObjectRef<SharedMessageInput$Shape> =
-  builder.inputRef<SharedMessageInput$Shape>("SharedMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<SharedMessageInput$Shape>("SharedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.same_dir.SharedMessage",
-        name: "SharedMessage",
-        package: "testapis.imports.same_dir",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.same_dir.SharedMessage",
+          name: "SharedMessage",
+          package: "testapis.imports.same_dir",
+        },
       },
-    },
-  }) as InputObjectRef<SharedMessageInput$Shape>;
+    }) as InputObjectRef<SharedMessageInput$Shape>;
 
 export function SharedMessageInput$toProto(
   input: SharedMessageInput$Shape | null | undefined,
 ): SharedMessage {
-  return create(SharedMessageSchema, { body: input?.body ?? undefined });
+  return create(SharedMessageSchema, {
+    body: input?.body ?? undefined,
+  });
 }
 
 export const SharedEnum$Ref: EnumRef<SharedEnum, SharedEnum> = builder.enumType(

--- a/tests/golden/protobuf-es/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/consumer.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/consumer.pb.pothos.ts
@@ -18,9 +18,8 @@ import {
 import { SharedEnum } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/imports/same_dir/base_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const Consumer$Ref = builder.objectRef<
-  MessageShape<typeof ConsumerSchema>
->("Consumer");
+export const Consumer$Ref =
+  builder.objectRef<MessageShape<typeof ConsumerSchema>>("Consumer");
 builder.objectType(Consumer$Ref, {
   name: "Consumer",
   fields: (t) => ({
@@ -70,7 +69,8 @@ export type ConsumerInput$Shape = {
 };
 
 export const ConsumerInput$Ref: InputObjectRef<ConsumerInput$Shape> = builder
-  .inputRef<ConsumerInput$Shape>("ConsumerInput").implement({
+  .inputRef<ConsumerInput$Shape>("ConsumerInput")
+  .implement({
     fields: (t) => ({
       message: t.field({
         type: SharedMessageInput$Ref,

--- a/tests/golden/protobuf-es/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg1.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg1.pb.pothos.ts
@@ -12,9 +12,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/imports/squashed_union/pkg1_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const OneofMessage1$Ref = builder.objectRef<
-  MessageShape<typeof OneofMessage1Schema>
->("OneofMessage1");
+export const OneofMessage1$Ref =
+  builder.objectRef<MessageShape<typeof OneofMessage1Schema>>("OneofMessage1");
 builder.objectType(OneofMessage1$Ref, {
   name: "OneofMessage1",
   fields: (t) => ({
@@ -36,30 +35,38 @@ builder.objectType(OneofMessage1$Ref, {
   },
 });
 
-export type OneofMessage1Input$Shape = { body: OneofMessage1["body"]; };
+export type OneofMessage1Input$Shape = {
+  body: OneofMessage1["body"];
+};
 
 export const OneofMessage1Input$Ref: InputObjectRef<OneofMessage1Input$Shape> =
-  builder.inputRef<OneofMessage1Input$Shape>("OneofMessage1Input").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<OneofMessage1Input$Shape>("OneofMessage1Input")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.squashed_union.pkg1.OneofMessage1",
-        name: "OneofMessage1",
-        package: "testapis.imports.squashed_union.pkg1",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.squashed_union.pkg1.OneofMessage1",
+          name: "OneofMessage1",
+          package: "testapis.imports.squashed_union.pkg1",
+        },
       },
-    },
-  }) as InputObjectRef<OneofMessage1Input$Shape>;
+    }) as InputObjectRef<OneofMessage1Input$Shape>;
 
 export function OneofMessage1Input$toProto(
   input: OneofMessage1Input$Shape | null | undefined,
 ): OneofMessage1 {
-  return create(OneofMessage1Schema, { body: input?.body ?? undefined });
+  return create(OneofMessage1Schema, {
+    body: input?.body ?? undefined,
+  });
 }
 
 export type SquashedOneofInput$Shape = {
@@ -67,28 +74,31 @@ export type SquashedOneofInput$Shape = {
 };
 
 export const SquashedOneofInput$Ref: InputObjectRef<SquashedOneofInput$Shape> =
-  builder.inputRef<SquashedOneofInput$Shape>("SquashedOneofInput").implement({
-    fields: (t) => ({
-      msg1: t.field({
-        type: OneofMessage1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "msg1",
-            typeFullName: "testapis.imports.squashed_union.pkg1.OneofMessage1",
+  builder
+    .inputRef<SquashedOneofInput$Shape>("SquashedOneofInput")
+    .implement({
+      fields: (t) => ({
+        msg1: t.field({
+          type: OneofMessage1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "msg1",
+              typeFullName:
+                "testapis.imports.squashed_union.pkg1.OneofMessage1",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.squashed_union.pkg1.SquashedOneof",
-        name: "SquashedOneof",
-        package: "testapis.imports.squashed_union.pkg1",
-        options: { "[graphql.object_type]": { squashUnion: true } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.squashed_union.pkg1.SquashedOneof",
+          name: "SquashedOneof",
+          package: "testapis.imports.squashed_union.pkg1",
+          options: { "[graphql.object_type]": { squashUnion: true } },
+        },
       },
-    },
-  }) as InputObjectRef<SquashedOneofInput$Shape>;
+    }) as InputObjectRef<SquashedOneofInput$Shape>;
 
 export function SquashedOneofInput$toProto(
   input: SquashedOneofInput$Shape | null | undefined,
@@ -107,11 +117,13 @@ export const SquashedOneof$Ref = builder.unionType("SquashedOneof", {
       fullName: "testapis.imports.squashed_union.pkg1.SquashedOneof",
       name: "SquashedOneof",
       package: "testapis.imports.squashed_union.pkg1",
-      fields: [{
-        name: "msg1",
-        type: "testapis.imports.squashed_union.pkg1.OneofMessage1",
-        options: { "[graphql.object_type]": { squashUnion: true } },
-      }],
+      fields: [
+        {
+          name: "msg1",
+          type: "testapis.imports.squashed_union.pkg1.OneofMessage1",
+          options: { "[graphql.object_type]": { squashUnion: true } },
+        },
+      ],
     },
   },
 });

--- a/tests/golden/protobuf-es/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg2.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg2.pb.pothos.ts
@@ -17,9 +17,8 @@ import {
 import { OneofMessage1 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/imports/squashed_union/pkg1_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const Message$Ref = builder.objectRef<
-  MessageShape<typeof MessageSchema>
->("Message");
+export const Message$Ref =
+  builder.objectRef<MessageShape<typeof MessageSchema>>("Message");
 builder.objectType(Message$Ref, {
   name: "Message",
   fields: (t) => ({
@@ -52,10 +51,13 @@ builder.objectType(Message$Ref, {
   },
 });
 
-export type MessageInput$Shape = { msg?: SquashedOneofInput$Shape | null; };
+export type MessageInput$Shape = {
+  msg?: SquashedOneofInput$Shape | null;
+};
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       msg: t.field({
         type: SquashedOneofInput$Ref,

--- a/tests/golden/protobuf-es/testapis.imports.transitive/__expected__/testapis/imports/transitive/a.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.transitive/__expected__/testapis/imports/transitive/a.pb.pothos.ts
@@ -38,32 +38,36 @@ builder.objectType(A$Ref, {
   },
 });
 
-export type AInput$Shape = { b?: BInput$Shape | null; };
+export type AInput$Shape = {
+  b?: BInput$Shape | null;
+};
 
-export const AInput$Ref: InputObjectRef<AInput$Shape> = builder.inputRef<
-  AInput$Shape
->("AInput").implement({
-  fields: (t) => ({
-    b: t.field({
-      type: BInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "b",
-          typeFullName: "testapis.imports.transitive.B",
+export const AInput$Ref: InputObjectRef<AInput$Shape> = builder
+  .inputRef<AInput$Shape>("AInput")
+  .implement({
+    fields: (t) => ({
+      b: t.field({
+        type: BInput$Ref,
+        required: false,
+        extensions: {
+          protobufField: {
+            name: "b",
+            typeFullName: "testapis.imports.transitive.B",
+          },
         },
-      },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.imports.transitive.A",
-      name: "A",
-      package: "testapis.imports.transitive",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.imports.transitive.A",
+        name: "A",
+        package: "testapis.imports.transitive",
+      },
     },
-  },
-}) as InputObjectRef<AInput$Shape>;
+  }) as InputObjectRef<AInput$Shape>;
 
 export function AInput$toProto(input: AInput$Shape | null | undefined): A {
-  return create(ASchema, { b: input?.b ? BInput$toProto(input.b) : undefined });
+  return create(ASchema, {
+    b: input?.b ? BInput$toProto(input.b) : undefined,
+  });
 }

--- a/tests/golden/protobuf-es/testapis.imports.transitive/__expected__/testapis/imports/transitive/b.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.transitive/__expected__/testapis/imports/transitive/b.pb.pothos.ts
@@ -38,32 +38,36 @@ builder.objectType(B$Ref, {
   },
 });
 
-export type BInput$Shape = { c?: CInput$Shape | null; };
+export type BInput$Shape = {
+  c?: CInput$Shape | null;
+};
 
-export const BInput$Ref: InputObjectRef<BInput$Shape> = builder.inputRef<
-  BInput$Shape
->("BInput").implement({
-  fields: (t) => ({
-    c: t.field({
-      type: CInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "c",
-          typeFullName: "testapis.imports.transitive.C",
+export const BInput$Ref: InputObjectRef<BInput$Shape> = builder
+  .inputRef<BInput$Shape>("BInput")
+  .implement({
+    fields: (t) => ({
+      c: t.field({
+        type: CInput$Ref,
+        required: false,
+        extensions: {
+          protobufField: {
+            name: "c",
+            typeFullName: "testapis.imports.transitive.C",
+          },
         },
-      },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.imports.transitive.B",
-      name: "B",
-      package: "testapis.imports.transitive",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.imports.transitive.B",
+        name: "B",
+        package: "testapis.imports.transitive",
+      },
     },
-  },
-}) as InputObjectRef<BInput$Shape>;
+  }) as InputObjectRef<BInput$Shape>;
 
 export function BInput$toProto(input: BInput$Shape | null | undefined): B {
-  return create(BSchema, { c: input?.c ? CInput$toProto(input.c) : undefined });
+  return create(BSchema, {
+    c: input?.c ? CInput$toProto(input.c) : undefined,
+  });
 }

--- a/tests/golden/protobuf-es/testapis.imports.transitive/__expected__/testapis/imports/transitive/c.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.imports.transitive/__expected__/testapis/imports/transitive/c.pb.pothos.ts
@@ -32,27 +32,31 @@ builder.objectType(C$Ref, {
   },
 });
 
-export type CInput$Shape = { body: C["body"]; };
+export type CInput$Shape = {
+  body: C["body"];
+};
 
-export const CInput$Ref: InputObjectRef<CInput$Shape> = builder.inputRef<
-  CInput$Shape
->("CInput").implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const CInput$Ref: InputObjectRef<CInput$Shape> = builder
+  .inputRef<CInput$Shape>("CInput")
+  .implement({
+    fields: (t) => ({
+      body: t.field({
+        type: "String",
+        required: true,
+        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.imports.transitive.C",
-      name: "C",
-      package: "testapis.imports.transitive",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.imports.transitive.C",
+        name: "C",
+        package: "testapis.imports.transitive",
+      },
     },
-  },
-}) as InputObjectRef<CInput$Shape>;
+  }) as InputObjectRef<CInput$Shape>;
 
 export function CInput$toProto(input: CInput$Shape | null | undefined): C {
-  return create(CSchema, { body: input?.body ?? undefined });
+  return create(CSchema, {
+    body: input?.body ?? undefined,
+  });
 }

--- a/tests/golden/protobuf-es/testapis.oneof.message_only/__expected__/testapis/oneof/message_only/message_only.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.oneof.message_only/__expected__/testapis/oneof/message_only/message_only.pb.pothos.ts
@@ -14,9 +14,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/oneof/message_only/message_only_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const OneofParent$Ref = builder.objectRef<
-  MessageShape<typeof OneofParentSchema>
->("OneofParent");
+export const OneofParent$Ref =
+  builder.objectRef<MessageShape<typeof OneofParentSchema>>("OneofParent");
 builder.objectType(OneofParent$Ref, {
   name: "OneofParent",
   fields: (t) => ({
@@ -127,64 +126,66 @@ export type OneofParentInput$Shape = {
 };
 
 export const OneofParentInput$Ref: InputObjectRef<OneofParentInput$Shape> =
-  builder.inputRef<OneofParentInput$Shape>("OneofParentInput").implement({
-    fields: (t) => ({
-      normalField: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: { name: "normal_field", typeFullName: "string" },
-        },
-      }),
-      requiredMessage1: t.field({
-        type: OneofMemberMessage1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "required_message1",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+  builder
+    .inputRef<OneofParentInput$Shape>("OneofParentInput")
+    .implement({
+      fields: (t) => ({
+        normalField: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "normal_field", typeFullName: "string" },
           },
-        },
-      }),
-      requiredMessage2: t.field({
-        type: OneofMemberMessage2Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "required_message2",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+        }),
+        requiredMessage1: t.field({
+          type: OneofMemberMessage1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "required_message1",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+            },
           },
-        },
-      }),
-      optionalMessage1: t.field({
-        type: OneofMemberMessage1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "optional_message1",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+        }),
+        requiredMessage2: t.field({
+          type: OneofMemberMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "required_message2",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+            },
           },
-        },
-      }),
-      optionalMessage2: t.field({
-        type: OneofMemberMessage2Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "optional_message2",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+        }),
+        optionalMessage1: t.field({
+          type: OneofMemberMessage1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "optional_message1",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+            },
           },
-        },
+        }),
+        optionalMessage2: t.field({
+          type: OneofMemberMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "optional_message2",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.message_only.OneofParent",
-        name: "OneofParent",
-        package: "testapis.oneof.message_only",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.message_only.OneofParent",
+          name: "OneofParent",
+          package: "testapis.oneof.message_only",
+        },
       },
-    },
-  }) as InputObjectRef<OneofParentInput$Shape>;
+    }) as InputObjectRef<OneofParentInput$Shape>;
 
 export function OneofParentInput$toProto(
   input: OneofParentInput$Shape | null | undefined,
@@ -193,26 +194,26 @@ export function OneofParentInput$toProto(
     normalField: input?.normalField ?? undefined,
     requiredOneofMembers: input?.requiredMessage1
       ? {
-        case: "requiredMessage1",
-        value: OneofMemberMessage1Input$toProto(input.requiredMessage1),
-      }
+          case: "requiredMessage1",
+          value: OneofMemberMessage1Input$toProto(input.requiredMessage1),
+        }
       : input?.requiredMessage2
-      ? {
-        case: "requiredMessage2",
-        value: OneofMemberMessage2Input$toProto(input.requiredMessage2),
-      }
-      : undefined,
+        ? {
+            case: "requiredMessage2",
+            value: OneofMemberMessage2Input$toProto(input.requiredMessage2),
+          }
+        : undefined,
     optionalOneofMembers: input?.optionalMessage1
       ? {
-        case: "optionalMessage1",
-        value: OneofMemberMessage1Input$toProto(input.optionalMessage1),
-      }
+          case: "optionalMessage1",
+          value: OneofMemberMessage1Input$toProto(input.optionalMessage1),
+        }
       : input?.optionalMessage2
-      ? {
-        case: "optionalMessage2",
-        value: OneofMemberMessage2Input$toProto(input.optionalMessage2),
-      }
-      : undefined,
+        ? {
+            case: "optionalMessage2",
+            value: OneofMemberMessage2Input$toProto(input.optionalMessage2),
+          }
+        : undefined,
   });
 }
 
@@ -220,57 +221,61 @@ export type OneofMemberMessage1Input$Shape = {
   body: OneofMemberMessage1["body"];
 };
 
-export const OneofMemberMessage1Input$Ref: InputObjectRef<
-  OneofMemberMessage1Input$Shape
-> = builder.inputRef<OneofMemberMessage1Input$Shape>("OneofMemberMessage1Input")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const OneofMemberMessage1Input$Ref: InputObjectRef<OneofMemberMessage1Input$Shape> =
+  builder
+    .inputRef<OneofMemberMessage1Input$Shape>("OneofMemberMessage1Input")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.message_only.OneofMemberMessage1",
-        name: "OneofMemberMessage1",
-        package: "testapis.oneof.message_only",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.message_only.OneofMemberMessage1",
+          name: "OneofMemberMessage1",
+          package: "testapis.oneof.message_only",
+        },
       },
-    },
-  }) as InputObjectRef<OneofMemberMessage1Input$Shape>;
+    }) as InputObjectRef<OneofMemberMessage1Input$Shape>;
 
 export function OneofMemberMessage1Input$toProto(
   input: OneofMemberMessage1Input$Shape | null | undefined,
 ): OneofMemberMessage1 {
-  return create(OneofMemberMessage1Schema, { body: input?.body ?? undefined });
+  return create(OneofMemberMessage1Schema, {
+    body: input?.body ?? undefined,
+  });
 }
 
 export type OneofMemberMessage2Input$Shape = {
   imageUrl: OneofMemberMessage2["imageUrl"];
 };
 
-export const OneofMemberMessage2Input$Ref: InputObjectRef<
-  OneofMemberMessage2Input$Shape
-> = builder.inputRef<OneofMemberMessage2Input$Shape>("OneofMemberMessage2Input")
-  .implement({
-    fields: (t) => ({
-      imageUrl: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: { name: "image_url", typeFullName: "string" },
-        },
+export const OneofMemberMessage2Input$Ref: InputObjectRef<OneofMemberMessage2Input$Shape> =
+  builder
+    .inputRef<OneofMemberMessage2Input$Shape>("OneofMemberMessage2Input")
+    .implement({
+      fields: (t) => ({
+        imageUrl: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "image_url", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.message_only.OneofMemberMessage2",
-        name: "OneofMemberMessage2",
-        package: "testapis.oneof.message_only",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.message_only.OneofMemberMessage2",
+          name: "OneofMemberMessage2",
+          package: "testapis.oneof.message_only",
+        },
       },
-    },
-  }) as InputObjectRef<OneofMemberMessage2Input$Shape>;
+    }) as InputObjectRef<OneofMemberMessage2Input$Shape>;
 
 export function OneofMemberMessage2Input$toProto(
   input: OneofMemberMessage2Input$Shape | null | undefined,
@@ -292,13 +297,16 @@ export const OneofParentRequiredOneofMembers$Ref = builder.unionType(
         name: "required_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "required_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "required_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "required_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "required_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },
@@ -315,13 +323,16 @@ export const OneofParentOptionalOneofMembers$Ref = builder.unionType(
         name: "optional_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "optional_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "optional_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "optional_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "optional_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },

--- a/tests/golden/protobuf-es/testapis.oneof.non_message/__expected__/testapis/oneof/non_message/non_message.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.oneof.non_message/__expected__/testapis/oneof/non_message/non_message.pb.pothos.ts
@@ -13,9 +13,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/oneof/non_message/non_message_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const OneofParent$Ref = builder.objectRef<
-  MessageShape<typeof OneofParentSchema>
->("OneofParent");
+export const OneofParent$Ref =
+  builder.objectRef<MessageShape<typeof OneofParentSchema>>("OneofParent");
 builder.objectType(OneofParent$Ref, {
   name: "OneofParent",
   fields: (t) => ({
@@ -43,9 +42,8 @@ builder.objectType(OneofParent$Ref, {
   },
 });
 
-export const MessageMember$Ref = builder.objectRef<
-  MessageShape<typeof MessageMemberSchema>
->("MessageMember");
+export const MessageMember$Ref =
+  builder.objectRef<MessageShape<typeof MessageMemberSchema>>("MessageMember");
 builder.objectType(MessageMember$Ref, {
   name: "MessageMember",
   fields: (t) => ({
@@ -72,27 +70,29 @@ export type OneofParentInput$Shape = {
 };
 
 export const OneofParentInput$Ref: InputObjectRef<OneofParentInput$Shape> =
-  builder.inputRef<OneofParentInput$Shape>("OneofParentInput").implement({
-    fields: (t) => ({
-      member: t.field({
-        type: MessageMemberInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "member",
-            typeFullName: "testapis.oneof.non_message.MessageMember",
+  builder
+    .inputRef<OneofParentInput$Shape>("OneofParentInput")
+    .implement({
+      fields: (t) => ({
+        member: t.field({
+          type: MessageMemberInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "member",
+              typeFullName: "testapis.oneof.non_message.MessageMember",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.non_message.OneofParent",
-        name: "OneofParent",
-        package: "testapis.oneof.non_message",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.non_message.OneofParent",
+          name: "OneofParent",
+          package: "testapis.oneof.non_message",
+        },
       },
-    },
-  }) as InputObjectRef<OneofParentInput$Shape>;
+    }) as InputObjectRef<OneofParentInput$Shape>;
 
 export function OneofParentInput$toProto(
   input: OneofParentInput$Shape | null | undefined,
@@ -104,30 +104,38 @@ export function OneofParentInput$toProto(
   });
 }
 
-export type MessageMemberInput$Shape = { body: MessageMember["body"]; };
+export type MessageMemberInput$Shape = {
+  body: MessageMember["body"];
+};
 
 export const MessageMemberInput$Ref: InputObjectRef<MessageMemberInput$Shape> =
-  builder.inputRef<MessageMemberInput$Shape>("MessageMemberInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<MessageMemberInput$Shape>("MessageMemberInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.non_message.MessageMember",
-        name: "MessageMember",
-        package: "testapis.oneof.non_message",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.non_message.MessageMember",
+          name: "MessageMember",
+          package: "testapis.oneof.non_message",
+        },
       },
-    },
-  }) as InputObjectRef<MessageMemberInput$Shape>;
+    }) as InputObjectRef<MessageMemberInput$Shape>;
 
 export function MessageMemberInput$toProto(
   input: MessageMemberInput$Shape | null | undefined,
 ): MessageMember {
-  return create(MessageMemberSchema, { body: input?.body ?? undefined });
+  return create(MessageMemberSchema, {
+    body: input?.body ?? undefined,
+  });
 }
 
 export const OneofParentMixedOneofMembers$Ref = builder.unionType(
@@ -140,10 +148,9 @@ export const OneofParentMixedOneofMembers$Ref = builder.unionType(
         name: "mixed_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.non_message",
-        fields: [{
-          name: "member",
-          type: "testapis.oneof.non_message.MessageMember",
-        }],
+        fields: [
+          { name: "member", type: "testapis.oneof.non_message.MessageMember" },
+        ],
       },
     },
   },

--- a/tests/golden/protobuf-es/testapis.options.deprecation/__expected__/testapis/options/deprecation/deprecation.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.options.deprecation/__expected__/testapis/options/deprecation/deprecation.pb.pothos.ts
@@ -20,9 +20,10 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/options/deprecation/deprecation_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const DeprecatedMessage$Ref = builder.objectRef<
-  MessageShape<typeof DeprecatedMessageSchema>
->("DeprecatedMessage");
+export const DeprecatedMessage$Ref =
+  builder.objectRef<MessageShape<typeof DeprecatedMessageSchema>>(
+    "DeprecatedMessage",
+  );
 builder.objectType(DeprecatedMessage$Ref, {
   name: "DeprecatedMessage",
   fields: (t) => ({
@@ -230,40 +231,42 @@ export type DeprecatedMessageInput$Shape = {
   enum?: DeprecatedMessage["enum"] | null;
 };
 
-export const DeprecatedMessageInput$Ref: InputObjectRef<
-  DeprecatedMessageInput$Shape
-> = builder.inputRef<DeprecatedMessageInput$Shape>("DeprecatedMessageInput")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: false,
-        deprecationReason:
-          "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      enum: t.field({
-        type: NotDeprecatedEnum$Ref,
-        required: false,
-        deprecationReason:
-          "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-        extensions: {
-          protobufField: {
-            name: "enum",
-            typeFullName: "testapis.options.deprecation.NotDeprecatedEnum",
+export const DeprecatedMessageInput$Ref: InputObjectRef<DeprecatedMessageInput$Shape> =
+  builder
+    .inputRef<DeprecatedMessageInput$Shape>("DeprecatedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
+        }),
+        enum: t.field({
+          type: NotDeprecatedEnum$Ref,
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: {
+              name: "enum",
+              typeFullName: "testapis.options.deprecation.NotDeprecatedEnum",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.deprecation.DeprecatedMessage",
-        name: "DeprecatedMessage",
-        package: "testapis.options.deprecation",
-        options: { deprecated: true },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.deprecation.DeprecatedMessage",
+          name: "DeprecatedMessage",
+          package: "testapis.options.deprecation",
+          options: { deprecated: true },
+        },
       },
-    },
-  }) as InputObjectRef<DeprecatedMessageInput$Shape>;
+    }) as InputObjectRef<DeprecatedMessageInput$Shape>;
 
 export function DeprecatedMessageInput$toProto(
   input: DeprecatedMessageInput$Shape | null | undefined,
@@ -283,100 +286,99 @@ export type NotDeprecatedMessageInput$Shape = {
   msg4?: NotDeprecatedMessageInnerMessage2Input$Shape | null;
 };
 
-export const NotDeprecatedMessageInput$Ref: InputObjectRef<
-  NotDeprecatedMessageInput$Shape
-> = builder.inputRef<NotDeprecatedMessageInput$Shape>(
-  "NotDeprecatedMessageInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.NotDeprecatedMessage.body is mark as deprecated in a *.proto file.",
+export const NotDeprecatedMessageInput$Ref: InputObjectRef<NotDeprecatedMessageInput$Shape> =
+  builder
+    .inputRef<NotDeprecatedMessageInput$Shape>("NotDeprecatedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.NotDeprecatedMessage.body is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "body",
+              typeFullName: "string",
+              options: { deprecated: true },
+            },
+          },
+        }),
+        enum: t.field({
+          type: DeprecatedEnum$Ref,
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "enum",
+              typeFullName: "testapis.options.deprecation.DeprecatedEnum",
+            },
+          },
+        }),
+        msg1: t.field({
+          type: NotDeprecatedMessageInnerMessage1Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: {
+              name: "msg1",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+            },
+          },
+        }),
+        msg2: t.field({
+          type: NotDeprecatedMessageInnerMessage2Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: {
+              name: "msg2",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+            },
+          },
+        }),
+        msg3: t.field({
+          type: NotDeprecatedMessageInnerMessage1Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.NotDeprecatedMessage.msg3 is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "msg3",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+              options: { deprecated: true },
+            },
+          },
+        }),
+        msg4: t.field({
+          type: NotDeprecatedMessageInnerMessage2Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.NotDeprecatedMessage.msg4 is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "msg4",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+              options: { deprecated: true },
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "body",
-          typeFullName: "string",
-          options: { deprecated: true },
+        protobufMessage: {
+          fullName: "testapis.options.deprecation.NotDeprecatedMessage",
+          name: "NotDeprecatedMessage",
+          package: "testapis.options.deprecation",
         },
       },
-    }),
-    enum: t.field({
-      type: DeprecatedEnum$Ref,
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.",
-      extensions: {
-        protobufField: {
-          name: "enum",
-          typeFullName: "testapis.options.deprecation.DeprecatedEnum",
-        },
-      },
-    }),
-    msg1: t.field({
-      type: NotDeprecatedMessageInnerMessage1Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: {
-        protobufField: {
-          name: "msg1",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-        },
-      },
-    }),
-    msg2: t.field({
-      type: NotDeprecatedMessageInnerMessage2Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: {
-        protobufField: {
-          name: "msg2",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-        },
-      },
-    }),
-    msg3: t.field({
-      type: NotDeprecatedMessageInnerMessage1Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.NotDeprecatedMessage.msg3 is mark as deprecated in a *.proto file.",
-      extensions: {
-        protobufField: {
-          name: "msg3",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-          options: { deprecated: true },
-        },
-      },
-    }),
-    msg4: t.field({
-      type: NotDeprecatedMessageInnerMessage2Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.NotDeprecatedMessage.msg4 is mark as deprecated in a *.proto file.",
-      extensions: {
-        protobufField: {
-          name: "msg4",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-          options: { deprecated: true },
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.deprecation.NotDeprecatedMessage",
-      name: "NotDeprecatedMessage",
-      package: "testapis.options.deprecation",
-    },
-  },
-}) as InputObjectRef<NotDeprecatedMessageInput$Shape>;
+    }) as InputObjectRef<NotDeprecatedMessageInput$Shape>;
 
 export function NotDeprecatedMessageInput$toProto(
   input: NotDeprecatedMessageInput$Shape | null | undefined,
@@ -386,26 +388,26 @@ export function NotDeprecatedMessageInput$toProto(
     enum: input?.enum ?? undefined,
     notDeprecatedOneof: input?.msg1
       ? {
-        case: "msg1",
-        value: NotDeprecatedMessageInnerMessage1Input$toProto(input.msg1),
-      }
+          case: "msg1",
+          value: NotDeprecatedMessageInnerMessage1Input$toProto(input.msg1),
+        }
       : input?.msg2
-      ? {
-        case: "msg2",
-        value: NotDeprecatedMessageInnerMessage2Input$toProto(input.msg2),
-      }
-      : undefined,
+        ? {
+            case: "msg2",
+            value: NotDeprecatedMessageInnerMessage2Input$toProto(input.msg2),
+          }
+        : undefined,
     deprecatedOneof: input?.msg3
       ? {
-        case: "msg3",
-        value: NotDeprecatedMessageInnerMessage1Input$toProto(input.msg3),
-      }
+          case: "msg3",
+          value: NotDeprecatedMessageInnerMessage1Input$toProto(input.msg3),
+        }
       : input?.msg4
-      ? {
-        case: "msg4",
-        value: NotDeprecatedMessageInnerMessage2Input$toProto(input.msg4),
-      }
-      : undefined,
+        ? {
+            case: "msg4",
+            value: NotDeprecatedMessageInnerMessage2Input$toProto(input.msg4),
+          }
+        : undefined,
   });
 }
 
@@ -413,28 +415,32 @@ export type DeprecatedMessageInnerMessageInput$Shape = {
   body?: DeprecatedMessage_InnerMessage["body"] | null;
 };
 
-export const DeprecatedMessageInnerMessageInput$Ref: InputObjectRef<
-  DeprecatedMessageInnerMessageInput$Shape
-> = builder.inputRef<DeprecatedMessageInnerMessageInput$Shape>(
-  "DeprecatedMessageInnerMessageInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.deprecation.DeprecatedMessage.InnerMessage",
-      name: "InnerMessage",
-      package: "testapis.options.deprecation",
-    },
-  },
-}) as InputObjectRef<DeprecatedMessageInnerMessageInput$Shape>;
+export const DeprecatedMessageInnerMessageInput$Ref: InputObjectRef<DeprecatedMessageInnerMessageInput$Shape> =
+  builder
+    .inputRef<DeprecatedMessageInnerMessageInput$Shape>(
+      "DeprecatedMessageInnerMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.deprecation.DeprecatedMessage.InnerMessage",
+          name: "InnerMessage",
+          package: "testapis.options.deprecation",
+        },
+      },
+    }) as InputObjectRef<DeprecatedMessageInnerMessageInput$Shape>;
 
 export function DeprecatedMessageInnerMessageInput$toProto(
   input: DeprecatedMessageInnerMessageInput$Shape | null | undefined,
@@ -448,29 +454,32 @@ export type NotDeprecatedMessageInnerMessage1Input$Shape = {
   body?: NotDeprecatedMessage_InnerMessage1["body"] | null;
 };
 
-export const NotDeprecatedMessageInnerMessage1Input$Ref: InputObjectRef<
-  NotDeprecatedMessageInnerMessage1Input$Shape
-> = builder.inputRef<NotDeprecatedMessageInnerMessage1Input$Shape>(
-  "NotDeprecatedMessageInnerMessage1Input",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-      name: "InnerMessage1",
-      package: "testapis.options.deprecation",
-    },
-  },
-}) as InputObjectRef<NotDeprecatedMessageInnerMessage1Input$Shape>;
+export const NotDeprecatedMessageInnerMessage1Input$Ref: InputObjectRef<NotDeprecatedMessageInnerMessage1Input$Shape> =
+  builder
+    .inputRef<NotDeprecatedMessageInnerMessage1Input$Shape>(
+      "NotDeprecatedMessageInnerMessage1Input",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+          name: "InnerMessage1",
+          package: "testapis.options.deprecation",
+        },
+      },
+    }) as InputObjectRef<NotDeprecatedMessageInnerMessage1Input$Shape>;
 
 export function NotDeprecatedMessageInnerMessage1Input$toProto(
   input: NotDeprecatedMessageInnerMessage1Input$Shape | null | undefined,
@@ -484,29 +493,32 @@ export type NotDeprecatedMessageInnerMessage2Input$Shape = {
   body?: NotDeprecatedMessage_InnerMessage2["body"] | null;
 };
 
-export const NotDeprecatedMessageInnerMessage2Input$Ref: InputObjectRef<
-  NotDeprecatedMessageInnerMessage2Input$Shape
-> = builder.inputRef<NotDeprecatedMessageInnerMessage2Input$Shape>(
-  "NotDeprecatedMessageInnerMessage2Input",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-      name: "InnerMessage2",
-      package: "testapis.options.deprecation",
-    },
-  },
-}) as InputObjectRef<NotDeprecatedMessageInnerMessage2Input$Shape>;
+export const NotDeprecatedMessageInnerMessage2Input$Ref: InputObjectRef<NotDeprecatedMessageInnerMessage2Input$Shape> =
+  builder
+    .inputRef<NotDeprecatedMessageInnerMessage2Input$Shape>(
+      "NotDeprecatedMessageInnerMessage2Input",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+          name: "InnerMessage2",
+          package: "testapis.options.deprecation",
+        },
+      },
+    }) as InputObjectRef<NotDeprecatedMessageInnerMessage2Input$Shape>;
 
 export function NotDeprecatedMessageInnerMessage2Input$toProto(
   input: NotDeprecatedMessageInnerMessage2Input$Shape | null | undefined,
@@ -530,15 +542,16 @@ export const NotDeprecatedMessageNotDeprecatedOneof$Ref = builder.unionType(
         name: "not_deprecated_oneof",
         messageName: "NotDeprecatedMessage",
         package: "testapis.options.deprecation",
-        fields: [{
-          name: "msg1",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-        }, {
-          name: "msg2",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-        }],
+        fields: [
+          {
+            name: "msg1",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+          },
+          {
+            name: "msg2",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+          },
+        ],
       },
     },
   },
@@ -558,15 +571,16 @@ export const NotDeprecatedMessageDeprecatedOneof$Ref = builder.unionType(
         name: "deprecated_oneof",
         messageName: "NotDeprecatedMessage",
         package: "testapis.options.deprecation",
-        fields: [{
-          name: "msg3",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-        }, {
-          name: "msg4",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-        }],
+        fields: [
+          {
+            name: "msg3",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+          },
+          {
+            name: "msg4",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+          },
+        ],
       },
     },
   },

--- a/tests/golden/protobuf-es/testapis.options.field_nullability/__expected__/testapis/options/field_nullability/field_nullability.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.options.field_nullability/__expected__/testapis/options/field_nullability/field_nullability.pb.pothos.ts
@@ -11,9 +11,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/options/field_nullability/field_nullability_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const Message$Ref = builder.objectRef<
-  MessageShape<typeof MessageSchema>
->("Message");
+export const Message$Ref =
+  builder.objectRef<MessageShape<typeof MessageSchema>>("Message");
 builder.objectType(Message$Ref, {
   name: "Message",
   fields: (t) => ({
@@ -85,7 +84,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       userId: t.field({
         type: "Int64",

--- a/tests/golden/protobuf-es/testapis.options.input_no_partial/__expected__/testapis/options/input_no_partial/input_no_partial.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.options.input_no_partial/__expected__/testapis/options/input_no_partial/input_no_partial.pb.pothos.ts
@@ -14,9 +14,8 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/options/input_no_partial/input_no_partial_pb";
 import { InputObjectRef } from "@pothos/core";
 
-export const ParentMessage$Ref = builder.objectRef<
-  MessageShape<typeof ParentMessageSchema>
->("ParentMessage");
+export const ParentMessage$Ref =
+  builder.objectRef<MessageShape<typeof ParentMessageSchema>>("ParentMessage");
 builder.objectType(ParentMessage$Ref, {
   name: "ParentMessage",
   fields: (t) => ({
@@ -132,41 +131,43 @@ export type ParentMessageInput$Shape = {
 };
 
 export const ParentMessageInput$Ref: InputObjectRef<ParentMessageInput$Shape> =
-  builder.inputRef<ParentMessageInput$Shape>("ParentMessageInput").implement({
-    fields: (t) => ({
-      partialableInputMessage: t.field({
-        type: PartialableInputMessageInput$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "partialable_input_message",
-            typeFullName:
-              "testapis.options.input_no_partial.PartialableInputMessage",
+  builder
+    .inputRef<ParentMessageInput$Shape>("ParentMessageInput")
+    .implement({
+      fields: (t) => ({
+        partialableInputMessage: t.field({
+          type: PartialableInputMessageInput$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "partialable_input_message",
+              typeFullName:
+                "testapis.options.input_no_partial.PartialableInputMessage",
+            },
           },
-        },
-      }),
-      noPartialInputMessage: t.field({
-        type: NoPartialInputMessageInput$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "no_partial_input_message",
-            typeFullName:
-              "testapis.options.input_no_partial.NoPartialInputMessage",
+        }),
+        noPartialInputMessage: t.field({
+          type: NoPartialInputMessageInput$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "no_partial_input_message",
+              typeFullName:
+                "testapis.options.input_no_partial.NoPartialInputMessage",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.input_no_partial.ParentMessage",
-        name: "ParentMessage",
-        package: "testapis.options.input_no_partial",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.input_no_partial.ParentMessage",
+          name: "ParentMessage",
+          package: "testapis.options.input_no_partial",
+        },
       },
-    },
-  }) as InputObjectRef<ParentMessageInput$Shape>;
+    }) as InputObjectRef<ParentMessageInput$Shape>;
 
 export function ParentMessageInput$toProto(
   input: ParentMessageInput$Shape | null | undefined,
@@ -186,33 +187,36 @@ export type PartialableInputMessageInput$Shape = {
   body: PartialableInputMessage["body"];
 };
 
-export const PartialableInputMessageInput$Ref: InputObjectRef<
-  PartialableInputMessageInput$Shape
-> = builder.inputRef<PartialableInputMessageInput$Shape>(
-  "PartialableInputMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.input_no_partial.PartialableInputMessage",
-      name: "PartialableInputMessage",
-      package: "testapis.options.input_no_partial",
-    },
-  },
-}) as InputObjectRef<PartialableInputMessageInput$Shape>;
+export const PartialableInputMessageInput$Ref: InputObjectRef<PartialableInputMessageInput$Shape> =
+  builder
+    .inputRef<PartialableInputMessageInput$Shape>(
+      "PartialableInputMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          description: "Required.",
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.input_no_partial.PartialableInputMessage",
+          name: "PartialableInputMessage",
+          package: "testapis.options.input_no_partial",
+        },
+      },
+    }) as InputObjectRef<PartialableInputMessageInput$Shape>;
 
 export function PartialableInputMessageInput$toProto(
   input: PartialableInputMessageInput$Shape | null | undefined,
@@ -228,34 +232,35 @@ export type NoPartialInputMessageInput$Shape = {
   body: NoPartialInputMessage["body"];
 };
 
-export const NoPartialInputMessageInput$Ref: InputObjectRef<
-  NoPartialInputMessageInput$Shape
-> = builder.inputRef<NoPartialInputMessageInput$Shape>(
-  "NoPartialInputMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.input_no_partial.NoPartialInputMessage",
-      name: "NoPartialInputMessage",
-      package: "testapis.options.input_no_partial",
-      options: { "[graphql.input_type]": { noPartial: true } },
-    },
-  },
-}) as InputObjectRef<NoPartialInputMessageInput$Shape>;
+export const NoPartialInputMessageInput$Ref: InputObjectRef<NoPartialInputMessageInput$Shape> =
+  builder
+    .inputRef<NoPartialInputMessageInput$Shape>("NoPartialInputMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          description: "Required.",
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.input_no_partial.NoPartialInputMessage",
+          name: "NoPartialInputMessage",
+          package: "testapis.options.input_no_partial",
+          options: { "[graphql.input_type]": { noPartial: true } },
+        },
+      },
+    }) as InputObjectRef<NoPartialInputMessageInput$Shape>;
 
 export function NoPartialInputMessageInput$toProto(
   input: NoPartialInputMessageInput$Shape | null | undefined,

--- a/tests/golden/protobuf-es/testapis.options.message_and_field/__expected__/testapis/options/message_and_field/message_and_field.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.options.message_and_field/__expected__/testapis/options/message_and_field/message_and_field.pb.pothos.ts
@@ -26,9 +26,10 @@ import {
 } from "@proto-graphql/e2e-testapis-protobuf-es-v2/lib/testapis/options/message_and_field/message_and_field_pb";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const PrefixedMessage$Ref = builder.objectRef<
-  MessageShape<typeof PrefixedMessageSchema>
->("PrefixedMessage");
+export const PrefixedMessage$Ref =
+  builder.objectRef<MessageShape<typeof PrefixedMessageSchema>>(
+    "PrefixedMessage",
+  );
 builder.objectType(PrefixedMessage$Ref, {
   name: "PrefixedMessage",
   fields: (t) => ({
@@ -194,9 +195,10 @@ builder.objectType(PrefixedMessage$Ref, {
   },
 });
 
-export const RenamedMessage$Ref = builder.objectRef<
-  MessageShape<typeof MessageWillRenameSchema>
->("RenamedMessage");
+export const RenamedMessage$Ref =
+  builder.objectRef<MessageShape<typeof MessageWillRenameSchema>>(
+    "RenamedMessage",
+  );
 builder.objectType(RenamedMessage$Ref, {
   name: "RenamedMessage",
   fields: (t) => ({
@@ -219,9 +221,10 @@ builder.objectType(RenamedMessage$Ref, {
   },
 });
 
-export const MessageOnlyOutput$Ref = builder.objectRef<
-  MessageShape<typeof MessageOnlyOutputSchema>
->("MessageOnlyOutput");
+export const MessageOnlyOutput$Ref =
+  builder.objectRef<MessageShape<typeof MessageOnlyOutputSchema>>(
+    "MessageOnlyOutput",
+  );
 builder.objectType(MessageOnlyOutput$Ref, {
   name: "MessageOnlyOutput",
   fields: (t) => ({
@@ -342,133 +345,135 @@ export type PrefixedMessageInput$Shape = {
   squashedMessages?: Array<PrefixedMessageSquashedMessageInput$Shape> | null;
 };
 
-export const PrefixedMessageInput$Ref: InputObjectRef<
-  PrefixedMessageInput$Shape
-> = builder.inputRef<PrefixedMessageInput$Shape>("PrefixedMessageInput")
-  .implement({
-    fields: (t) => ({
-      id: t.field({
-        type: "Int64",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "id",
-            typeFullName: "uint64",
-            options: { "[graphql.field]": { id: true } },
+export const PrefixedMessageInput$Ref: InputObjectRef<PrefixedMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInput$Shape>("PrefixedMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "id",
+              typeFullName: "uint64",
+              options: { "[graphql.field]": { id: true } },
+            },
           },
-        },
-      }),
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      prefixedEnum: t.field({
-        type: PrefixedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "prefixed_enum",
-            typeFullName: "testapis.options.message_and_field.PrefixedEnum",
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
-      }),
-      thisFieldWasRenamed: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "this_field_will_be_renamed",
-            typeFullName: "string",
-            options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
+        }),
+        prefixedEnum: t.field({
+          type: PrefixedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "prefixed_enum",
+              typeFullName: "testapis.options.message_and_field.PrefixedEnum",
+            },
           },
-        },
-      }),
-      skipResolver: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "skip_resolver",
-            typeFullName: "string",
-            options: { "[graphql.field]": { skipResolver: true } },
+        }),
+        thisFieldWasRenamed: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "this_field_will_be_renamed",
+              typeFullName: "string",
+              options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
+            },
           },
-        },
-      }),
-      squashedMessage: t.field({
-        type: PrefixedMessageSquashedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "squashed_message",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+        }),
+        skipResolver: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "skip_resolver",
+              typeFullName: "string",
+              options: { "[graphql.field]": { skipResolver: true } },
+            },
           },
-        },
-      }),
-      renamedMessage: t.field({
-        type: RenamedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "renamed_message",
-            typeFullName:
-              "testapis.options.message_and_field.MessageWillRename",
+        }),
+        squashedMessage: t.field({
+          type: PrefixedMessageSquashedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "squashed_message",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
           },
-        },
-      }),
-      renamedEnum: t.field({
-        type: RenamedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "renamed_enum",
-            typeFullName: "testapis.options.message_and_field.EnumWillRename",
+        }),
+        renamedMessage: t.field({
+          type: RenamedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_message",
+              typeFullName:
+                "testapis.options.message_and_field.MessageWillRename",
+            },
           },
-        },
-      }),
-      notIgnoredMessage: t.field({
-        type: IgnoredMessageNotIgnoredInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "not_ignored_message",
-            typeFullName:
-              "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+        }),
+        renamedEnum: t.field({
+          type: RenamedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_enum",
+              typeFullName: "testapis.options.message_and_field.EnumWillRename",
+            },
           },
-        },
-      }),
-      oneofNotIgnoredField: t.field({
-        type: PrefixedMessageInnerMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "oneof_not_ignored_field",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+        }),
+        notIgnoredMessage: t.field({
+          type: IgnoredMessageNotIgnoredInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "not_ignored_message",
+              typeFullName:
+                "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+            },
           },
-        },
-      }),
-      squashedMessages: t.field({
-        type: [PrefixedMessageSquashedMessageInput$Ref],
-        required: { list: false, items: true },
-        extensions: {
-          protobufField: {
-            name: "squashed_messages",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+        }),
+        oneofNotIgnoredField: t.field({
+          type: PrefixedMessageInnerMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_not_ignored_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
           },
-        },
+        }),
+        squashedMessages: t.field({
+          type: [PrefixedMessageSquashedMessageInput$Ref],
+          required: { list: false, items: true },
+          extensions: {
+            protobufField: {
+              name: "squashed_messages",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.PrefixedMessage",
-        name: "PrefixedMessage",
-        package: "testapis.options.message_and_field",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.PrefixedMessage",
+          name: "PrefixedMessage",
+          package: "testapis.options.message_and_field",
+        },
       },
-    },
-  }) as InputObjectRef<PrefixedMessageInput$Shape>;
+    }) as InputObjectRef<PrefixedMessageInput$Shape>;
 
 export function PrefixedMessageInput$toProto(
   input: PrefixedMessageInput$Shape | null | undefined,
@@ -490,75 +495,85 @@ export function PrefixedMessageInput$toProto(
       ? IgnoredMessageNotIgnoredInput$toProto(input.notIgnoredMessage)
       : undefined,
     squashedMessages: input?.squashedMessages?.map((v) =>
-      PrefixedMessageSquashedMessageInput$toProto(v)
+      PrefixedMessageSquashedMessageInput$toProto(v),
     ),
     partialIgnoreOneof: input?.oneofNotIgnoredField
       ? {
-        case: "oneofNotIgnoredField",
-        value: PrefixedMessageInnerMessageInput$toProto(
-          input.oneofNotIgnoredField,
-        ),
-      }
+          case: "oneofNotIgnoredField",
+          value: PrefixedMessageInnerMessageInput$toProto(
+            input.oneofNotIgnoredField,
+          ),
+        }
       : undefined,
   });
 }
 
-export type RenamedMessageInput$Shape = { body: MessageWillRename["body"]; };
+export type RenamedMessageInput$Shape = {
+  body: MessageWillRename["body"];
+};
 
-export const RenamedMessageInput$Ref: InputObjectRef<
-  RenamedMessageInput$Shape
-> = builder.inputRef<RenamedMessageInput$Shape>("RenamedMessageInput")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const RenamedMessageInput$Ref: InputObjectRef<RenamedMessageInput$Shape> =
+  builder
+    .inputRef<RenamedMessageInput$Shape>("RenamedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.MessageWillRename",
-        name: "MessageWillRename",
-        package: "testapis.options.message_and_field",
-        options: { "[graphql.object_type]": { name: "RenamedMessage" } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.MessageWillRename",
+          name: "MessageWillRename",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { name: "RenamedMessage" } },
+        },
       },
-    },
-  }) as InputObjectRef<RenamedMessageInput$Shape>;
+    }) as InputObjectRef<RenamedMessageInput$Shape>;
 
 export function RenamedMessageInput$toProto(
   input: RenamedMessageInput$Shape | null | undefined,
 ): MessageWillRename {
-  return create(MessageWillRenameSchema, { body: input?.body ?? undefined });
+  return create(MessageWillRenameSchema, {
+    body: input?.body ?? undefined,
+  });
 }
 
-export type InterfaceMessageInput$Shape = { id: InterfaceMessage["id"]; };
+export type InterfaceMessageInput$Shape = {
+  id: InterfaceMessage["id"];
+};
 
-export const InterfaceMessageInput$Ref: InputObjectRef<
-  InterfaceMessageInput$Shape
-> = builder.inputRef<InterfaceMessageInput$Shape>("InterfaceMessageInput")
-  .implement({
-    fields: (t) => ({
-      id: t.field({
-        type: "Int64",
-        required: true,
-        extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+export const InterfaceMessageInput$Ref: InputObjectRef<InterfaceMessageInput$Shape> =
+  builder
+    .inputRef<InterfaceMessageInput$Shape>("InterfaceMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.InterfaceMessage",
-        name: "InterfaceMessage",
-        package: "testapis.options.message_and_field",
-        options: { "[graphql.object_type]": { interface: true } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.InterfaceMessage",
+          name: "InterfaceMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { interface: true } },
+        },
       },
-    },
-  }) as InputObjectRef<InterfaceMessageInput$Shape>;
+    }) as InputObjectRef<InterfaceMessageInput$Shape>;
 
 export function InterfaceMessageInput$toProto(
   input: InterfaceMessageInput$Shape | null | undefined,
 ): InterfaceMessage {
-  return create(InterfaceMessageSchema, { id: input?.id ?? undefined });
+  return create(InterfaceMessageSchema, {
+    id: input?.id ?? undefined,
+  });
 }
 
 export type PrefixedMessageInnerMessageInput$Shape = {
@@ -566,32 +581,35 @@ export type PrefixedMessageInnerMessageInput$Shape = {
   body: PrefixedMessage_InnerMessage["body"];
 };
 
-export const PrefixedMessageInnerMessageInput$Ref: InputObjectRef<
-  PrefixedMessageInnerMessageInput$Shape
-> = builder.inputRef<PrefixedMessageInnerMessageInput$Shape>(
-  "PrefixedMessageInnerMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-      name: "InnerMessage",
-      package: "testapis.options.message_and_field",
-    },
-  },
-}) as InputObjectRef<PrefixedMessageInnerMessageInput$Shape>;
+export const PrefixedMessageInnerMessageInput$Ref: InputObjectRef<PrefixedMessageInnerMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessageInput$Shape>(
+      "PrefixedMessageInnerMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+          name: "InnerMessage",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    }) as InputObjectRef<PrefixedMessageInnerMessageInput$Shape>;
 
 export function PrefixedMessageInnerMessageInput$toProto(
   input: PrefixedMessageInnerMessageInput$Shape | null | undefined,
@@ -607,32 +625,35 @@ export type PrefixedMessageInnerMessage2Input$Shape = {
   body: PrefixedMessage_InnerMessage2["body"];
 };
 
-export const PrefixedMessageInnerMessage2Input$Ref: InputObjectRef<
-  PrefixedMessageInnerMessage2Input$Shape
-> = builder.inputRef<PrefixedMessageInnerMessage2Input$Shape>(
-  "PrefixedMessageInnerMessage2Input",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-      name: "InnerMessage2",
-      package: "testapis.options.message_and_field",
-    },
-  },
-}) as InputObjectRef<PrefixedMessageInnerMessage2Input$Shape>;
+export const PrefixedMessageInnerMessage2Input$Ref: InputObjectRef<PrefixedMessageInnerMessage2Input$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessage2Input$Shape>(
+      "PrefixedMessageInnerMessage2Input",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+          name: "InnerMessage2",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    }) as InputObjectRef<PrefixedMessageInnerMessage2Input$Shape>;
 
 export function PrefixedMessageInnerMessage2Input$toProto(
   input: PrefixedMessageInnerMessage2Input$Shape | null | undefined,
@@ -648,45 +669,46 @@ export type PrefixedMessageSquashedMessageInput$Shape = {
   oneofField2?: PrefixedMessageInnerMessage2Input$Shape | null;
 };
 
-export const PrefixedMessageSquashedMessageInput$Ref: InputObjectRef<
-  PrefixedMessageSquashedMessageInput$Shape
-> = builder.inputRef<PrefixedMessageSquashedMessageInput$Shape>(
-  "PrefixedMessageSquashedMessageInput",
-).implement({
-  fields: (t) => ({
-    oneofField: t.field({
-      type: PrefixedMessageInnerMessageInput$Ref,
-      required: false,
+export const PrefixedMessageSquashedMessageInput$Ref: InputObjectRef<PrefixedMessageSquashedMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageSquashedMessageInput$Shape>(
+      "PrefixedMessageSquashedMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        oneofField: t.field({
+          type: PrefixedMessageInnerMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
+          },
+        }),
+        oneofField2: t.field({
+          type: PrefixedMessageInnerMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field_2",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "oneof_field",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+          name: "SquashedMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { squashUnion: true } },
         },
       },
-    }),
-    oneofField2: t.field({
-      type: PrefixedMessageInnerMessage2Input$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "oneof_field_2",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
-      name: "SquashedMessage",
-      package: "testapis.options.message_and_field",
-      options: { "[graphql.object_type]": { squashUnion: true } },
-    },
-  },
-}) as InputObjectRef<PrefixedMessageSquashedMessageInput$Shape>;
+    }) as InputObjectRef<PrefixedMessageSquashedMessageInput$Shape>;
 
 export function PrefixedMessageSquashedMessageInput$toProto(
   input: PrefixedMessageSquashedMessageInput$Shape | null | undefined,
@@ -694,15 +716,15 @@ export function PrefixedMessageSquashedMessageInput$toProto(
   return create(PrefixedMessage_SquashedMessageSchema, {
     squashedMessage: input?.oneofField
       ? {
-        case: "oneofField",
-        value: PrefixedMessageInnerMessageInput$toProto(input.oneofField),
-      }
+          case: "oneofField",
+          value: PrefixedMessageInnerMessageInput$toProto(input.oneofField),
+        }
       : input?.oneofField2
-      ? {
-        case: "oneofField2",
-        value: PrefixedMessageInnerMessage2Input$toProto(input.oneofField2),
-      }
-      : undefined,
+        ? {
+            case: "oneofField2",
+            value: PrefixedMessageInnerMessage2Input$toProto(input.oneofField2),
+          }
+        : undefined,
   });
 }
 
@@ -710,26 +732,30 @@ export type IgnoredMessageNotIgnoredInput$Shape = {
   body: IgnoredMessage_NotIgnored["body"];
 };
 
-export const IgnoredMessageNotIgnoredInput$Ref: InputObjectRef<
-  IgnoredMessageNotIgnoredInput$Shape
-> = builder.inputRef<IgnoredMessageNotIgnoredInput$Shape>(
-  "IgnoredMessageNotIgnoredInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
-      name: "NotIgnored",
-      package: "testapis.options.message_and_field",
-    },
-  },
-}) as InputObjectRef<IgnoredMessageNotIgnoredInput$Shape>;
+export const IgnoredMessageNotIgnoredInput$Ref: InputObjectRef<IgnoredMessageNotIgnoredInput$Shape> =
+  builder
+    .inputRef<IgnoredMessageNotIgnoredInput$Shape>(
+      "IgnoredMessageNotIgnoredInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+          name: "NotIgnored",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    }) as InputObjectRef<IgnoredMessageNotIgnoredInput$Shape>;
 
 export function IgnoredMessageNotIgnoredInput$toProto(
   input: IgnoredMessageNotIgnoredInput$Shape | null | undefined,
@@ -739,9 +765,10 @@ export function IgnoredMessageNotIgnoredInput$toProto(
   });
 }
 
-export const InterfaceMessage$Ref = builder.interfaceRef<
-  Pick<MessageShape<typeof InterfaceMessageSchema>, "id">
->("InterfaceMessage");
+export const InterfaceMessage$Ref =
+  builder.interfaceRef<Pick<MessageShape<typeof InterfaceMessageSchema>, "id">>(
+    "InterfaceMessage",
+  );
 builder.interfaceType(InterfaceMessage$Ref, {
   name: "InterfaceMessage",
   fields: (t) => ({
@@ -771,17 +798,18 @@ export const PrefixedMessageSquashedMessage$Ref = builder.unionType(
           "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
         name: "SquashedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }, {
-          name: "oneof_field_2",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }],
+        fields: [
+          {
+            name: "oneof_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+          {
+            name: "oneof_field_2",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+        ],
       },
     },
   },
@@ -798,18 +826,19 @@ export const PrefixedMessagePartialIgnoreOneof$Ref = builder.unionType(
         name: "partial_ignore_oneof",
         messageName: "PrefixedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_not_ignored_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-        }],
+        fields: [
+          {
+            name: "oneof_not_ignored_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+          },
+        ],
       },
     },
   },
 );
 
-export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> = builder
-  .enumType("RenamedEnum", {
+export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> =
+  builder.enumType("RenamedEnum", {
     values: {
       FOO: {
         value: 1,
@@ -830,8 +859,8 @@ export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> = builder
     },
   });
 
-export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> = builder
-  .enumType("PrefixedEnum", {
+export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> =
+  builder.enumType("PrefixedEnum", {
     values: {
       PREFIXED_FOO: {
         value: 1,

--- a/tests/golden/protobuf-es/testapis.options.schema/__expected__/testapis/options/schema/schema.pb.pothos.ts
+++ b/tests/golden/protobuf-es/testapis.options.schema/__expected__/testapis/options/schema/schema.pb.pothos.ts
@@ -44,31 +44,34 @@ export type SchemaPrefixPostResponseInput$Shape = {
   body: PostResponse["body"];
 };
 
-export const SchemaPrefixPostResponseInput$Ref: InputObjectRef<
-  SchemaPrefixPostResponseInput$Shape
-> = builder.inputRef<SchemaPrefixPostResponseInput$Shape>(
-  "SchemaPrefixPostResponseInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "Int64",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.schema.PostResponse",
-      name: "PostResponse",
-      package: "testapis.options.schema",
-    },
-  },
-}) as InputObjectRef<SchemaPrefixPostResponseInput$Shape>;
+export const SchemaPrefixPostResponseInput$Ref: InputObjectRef<SchemaPrefixPostResponseInput$Shape> =
+  builder
+    .inputRef<SchemaPrefixPostResponseInput$Shape>(
+      "SchemaPrefixPostResponseInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "Int64",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.schema.PostResponse",
+          name: "PostResponse",
+          package: "testapis.options.schema",
+        },
+      },
+    }) as InputObjectRef<SchemaPrefixPostResponseInput$Shape>;
 
 export function SchemaPrefixPostResponseInput$toProto(
   input: SchemaPrefixPostResponseInput$Shape | null | undefined,

--- a/tests/golden/ts-proto-forcelong/testapis.basic.scalars/__expected__/testapis/basic/scalars/scalars.pb.pothos.ts
+++ b/tests/golden/ts-proto-forcelong/testapis.basic.scalars/__expected__/testapis/basic/scalars/scalars.pb.pothos.ts
@@ -65,8 +65,10 @@ builder.objectType(Message$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Message | { $type: string & {}; }).$type ===
-      "testapis.basic.scalars.Message";
+    return (
+      (source as Message | { $type: string & {} }).$type ===
+      "testapis.basic.scalars.Message"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -359,8 +361,10 @@ builder.objectType(Primitives$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Primitives | { $type: string & {}; }).$type ===
-      "testapis.basic.scalars.Primitives";
+    return (
+      (source as Primitives | { $type: string & {} }).$type ===
+      "testapis.basic.scalars.Primitives"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -379,7 +383,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredPrimitives: t.field({
         type: PrimitivesInput$Ref,
@@ -469,308 +474,316 @@ export type PrimitivesInput$Shape = {
 };
 
 export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
-  builder.inputRef<PrimitivesInput$Shape>("PrimitivesInput").implement({
-    fields: (t) => ({
-      requiredDoubleValue: t.field({
-        type: "Float",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_double_value",
-            typeFullName: "double",
+  builder
+    .inputRef<PrimitivesInput$Shape>("PrimitivesInput")
+    .implement({
+      fields: (t) => ({
+        requiredDoubleValue: t.field({
+          type: "Float",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_double_value",
+              typeFullName: "double",
+            },
           },
-        },
-      }),
-      requiredFloatValue: t.field({
-        type: "Float",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_float_value",
-            typeFullName: "float",
+        }),
+        requiredFloatValue: t.field({
+          type: "Float",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_float_value",
+              typeFullName: "float",
+            },
           },
-        },
-      }),
-      requiredInt32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_int32_value",
-            typeFullName: "int32",
+        }),
+        requiredInt32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_int32_value",
+              typeFullName: "int32",
+            },
           },
-        },
-      }),
-      requiredInt64Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_int64_value",
-            typeFullName: "int64",
+        }),
+        requiredInt64Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_int64_value",
+              typeFullName: "int64",
+            },
           },
-        },
-      }),
-      requiredUint32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_uint32_value",
-            typeFullName: "uint32",
+        }),
+        requiredUint32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_uint32_value",
+              typeFullName: "uint32",
+            },
           },
-        },
-      }),
-      requiredUint64Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_uint64_value",
-            typeFullName: "uint64",
+        }),
+        requiredUint64Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_uint64_value",
+              typeFullName: "uint64",
+            },
           },
-        },
-      }),
-      requiredSint32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sint32_value",
-            typeFullName: "sint32",
+        }),
+        requiredSint32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sint32_value",
+              typeFullName: "sint32",
+            },
           },
-        },
-      }),
-      requiredSint64Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sint64_value",
-            typeFullName: "sint64",
+        }),
+        requiredSint64Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sint64_value",
+              typeFullName: "sint64",
+            },
           },
-        },
-      }),
-      requiredFixed32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_fixed32_value",
-            typeFullName: "fixed32",
+        }),
+        requiredFixed32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_fixed32_value",
+              typeFullName: "fixed32",
+            },
           },
-        },
-      }),
-      requiredFixed64Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_fixed64_value",
-            typeFullName: "fixed64",
+        }),
+        requiredFixed64Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_fixed64_value",
+              typeFullName: "fixed64",
+            },
           },
-        },
-      }),
-      requiredSfixed32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sfixed32_value",
-            typeFullName: "sfixed32",
+        }),
+        requiredSfixed32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sfixed32_value",
+              typeFullName: "sfixed32",
+            },
           },
-        },
-      }),
-      requiredSfixed64Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sfixed64_value",
-            typeFullName: "sfixed64",
+        }),
+        requiredSfixed64Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sfixed64_value",
+              typeFullName: "sfixed64",
+            },
           },
-        },
-      }),
-      requiredBoolValue: t.field({
-        type: "Boolean",
-        required: true,
-        extensions: {
-          protobufField: { name: "required_bool_value", typeFullName: "bool" },
-        },
-      }),
-      requiredStringValue: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_string_value",
-            typeFullName: "string",
+        }),
+        requiredBoolValue: t.field({
+          type: "Boolean",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_bool_value",
+              typeFullName: "bool",
+            },
           },
-        },
-      }),
-      requiredBytesValue: t.field({
-        type: "Byte",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_bytes_value",
-            typeFullName: "bytes",
+        }),
+        requiredStringValue: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_string_value",
+              typeFullName: "string",
+            },
           },
-        },
-      }),
-      requiredDoubleValues: t.field({
-        type: ["Float"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_double_values",
-            typeFullName: "double",
+        }),
+        requiredBytesValue: t.field({
+          type: "Byte",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_bytes_value",
+              typeFullName: "bytes",
+            },
           },
-        },
-      }),
-      requiredFloatValues: t.field({
-        type: ["Float"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_float_values",
-            typeFullName: "float",
+        }),
+        requiredDoubleValues: t.field({
+          type: ["Float"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_double_values",
+              typeFullName: "double",
+            },
           },
-        },
-      }),
-      requiredInt32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_int32_values",
-            typeFullName: "int32",
+        }),
+        requiredFloatValues: t.field({
+          type: ["Float"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_float_values",
+              typeFullName: "float",
+            },
           },
-        },
-      }),
-      requiredInt64Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_int64_values",
-            typeFullName: "int64",
+        }),
+        requiredInt32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_int32_values",
+              typeFullName: "int32",
+            },
           },
-        },
-      }),
-      requiredUint32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_uint32_values",
-            typeFullName: "uint32",
+        }),
+        requiredInt64Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_int64_values",
+              typeFullName: "int64",
+            },
           },
-        },
-      }),
-      requiredUint64Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_uint64_values",
-            typeFullName: "uint64",
+        }),
+        requiredUint32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_uint32_values",
+              typeFullName: "uint32",
+            },
           },
-        },
-      }),
-      requiredSint32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sint32_values",
-            typeFullName: "sint32",
+        }),
+        requiredUint64Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_uint64_values",
+              typeFullName: "uint64",
+            },
           },
-        },
-      }),
-      requiredSint64Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sint64_values",
-            typeFullName: "sint64",
+        }),
+        requiredSint32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sint32_values",
+              typeFullName: "sint32",
+            },
           },
-        },
-      }),
-      requiredFixed32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_fixed32_values",
-            typeFullName: "fixed32",
+        }),
+        requiredSint64Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sint64_values",
+              typeFullName: "sint64",
+            },
           },
-        },
-      }),
-      requiredFixed64Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_fixed64_values",
-            typeFullName: "fixed64",
+        }),
+        requiredFixed32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_fixed32_values",
+              typeFullName: "fixed32",
+            },
           },
-        },
-      }),
-      requiredSfixed32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sfixed32_values",
-            typeFullName: "sfixed32",
+        }),
+        requiredFixed64Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_fixed64_values",
+              typeFullName: "fixed64",
+            },
           },
-        },
-      }),
-      requiredSfixed64Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sfixed64_values",
-            typeFullName: "sfixed64",
+        }),
+        requiredSfixed32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sfixed32_values",
+              typeFullName: "sfixed32",
+            },
           },
-        },
-      }),
-      requiredBoolValues: t.field({
-        type: ["Boolean"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: { name: "required_bool_values", typeFullName: "bool" },
-        },
-      }),
-      requiredStringValues: t.field({
-        type: ["String"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_string_values",
-            typeFullName: "string",
+        }),
+        requiredSfixed64Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sfixed64_values",
+              typeFullName: "sfixed64",
+            },
           },
-        },
-      }),
-      requiredBytesValues: t.field({
-        type: ["Byte"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_bytes_values",
-            typeFullName: "bytes",
+        }),
+        requiredBoolValues: t.field({
+          type: ["Boolean"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_bool_values",
+              typeFullName: "bool",
+            },
           },
-        },
+        }),
+        requiredStringValues: t.field({
+          type: ["String"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_string_values",
+              typeFullName: "string",
+            },
+          },
+        }),
+        requiredBytesValues: t.field({
+          type: ["Byte"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_bytes_values",
+              typeFullName: "bytes",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.scalars.Primitives",
-        name: "Primitives",
-        package: "testapis.basic.scalars",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.scalars.Primitives",
+          name: "Primitives",
+          package: "testapis.basic.scalars",
+        },
       },
-    },
-  });
+    });

--- a/tests/golden/ts-proto-forcelong/testapis.basic.wktypes/__expected__/testapis/basic/wktypes/wktypes.pb.pothos.ts
+++ b/tests/golden/ts-proto-forcelong/testapis.basic.wktypes/__expected__/testapis/basic/wktypes/wktypes.pb.pothos.ts
@@ -131,8 +131,10 @@ builder.objectType(Message$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Message | { $type: string & {}; }).$type ===
-      "testapis.basic.wktypes.Message";
+    return (
+      (source as Message | { $type: string & {} }).$type ===
+      "testapis.basic.wktypes.Message"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -158,7 +160,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       timestamp: t.field({
         type: "DateTime",

--- a/tests/golden/ts-proto-partial-inputs/testapis.options.message_and_field/__expected__/testapis/options/message_and_field/message_and_field.pb.pothos.ts
+++ b/tests/golden/ts-proto-partial-inputs/testapis.options.message_and_field/__expected__/testapis/options/message_and_field/message_and_field.pb.pothos.ts
@@ -17,9 +17,8 @@ import {
 } from "@proto-graphql/e2e-testapis-ts-proto/lib/testapis/options/message_and_field/message_and_field";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const PrefixedMessage$Ref = builder.objectRef<PrefixedMessage>(
-  "PrefixedMessage",
-);
+export const PrefixedMessage$Ref =
+  builder.objectRef<PrefixedMessage>("PrefixedMessage");
 builder.objectType(PrefixedMessage$Ref, {
   name: "PrefixedMessage",
   fields: (t) => ({
@@ -86,7 +85,8 @@ builder.objectType(PrefixedMessage$Ref, {
       type: PrefixedMessageSquashedMessage$Ref,
       nullable: true,
       resolve: (source) => {
-        const value = source.squashedMessage?.oneofField ??
+        const value =
+          source.squashedMessage?.oneofField ??
           source.squashedMessage?.oneofField2;
         if (value == null) {
           return null;
@@ -175,8 +175,10 @@ builder.objectType(PrefixedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as PrefixedMessage | { $type: string & {}; }).$type ===
-      "testapis.options.message_and_field.PrefixedMessage";
+    return (
+      (source as PrefixedMessage | { $type: string & {} }).$type ===
+      "testapis.options.message_and_field.PrefixedMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -187,9 +189,8 @@ builder.objectType(PrefixedMessage$Ref, {
   },
 });
 
-export const RenamedMessage$Ref = builder.objectRef<MessageWillRename>(
-  "RenamedMessage",
-);
+export const RenamedMessage$Ref =
+  builder.objectRef<MessageWillRename>("RenamedMessage");
 builder.objectType(RenamedMessage$Ref, {
   name: "RenamedMessage",
   fields: (t) => ({
@@ -200,8 +201,10 @@ builder.objectType(RenamedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as MessageWillRename | { $type: string & {}; }).$type ===
-      "testapis.options.message_and_field.MessageWillRename";
+    return (
+      (source as MessageWillRename | { $type: string & {} }).$type ===
+      "testapis.options.message_and_field.MessageWillRename"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -213,9 +216,8 @@ builder.objectType(RenamedMessage$Ref, {
   },
 });
 
-export const MessageOnlyOutput$Ref = builder.objectRef<MessageOnlyOutput>(
-  "MessageOnlyOutput",
-);
+export const MessageOnlyOutput$Ref =
+  builder.objectRef<MessageOnlyOutput>("MessageOnlyOutput");
 builder.objectType(MessageOnlyOutput$Ref, {
   name: "MessageOnlyOutput",
   fields: (t) => ({
@@ -226,8 +228,10 @@ builder.objectType(MessageOnlyOutput$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as MessageOnlyOutput | { $type: string & {}; }).$type ===
-      "testapis.options.message_and_field.MessageOnlyOutput";
+    return (
+      (source as MessageOnlyOutput | { $type: string & {} }).$type ===
+      "testapis.options.message_and_field.MessageOnlyOutput"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -239,9 +243,10 @@ builder.objectType(MessageOnlyOutput$Ref, {
   },
 });
 
-export const PrefixedMessageInnerMessage$Ref = builder.objectRef<
-  PrefixedMessage_InnerMessage
->("PrefixedMessageInnerMessage");
+export const PrefixedMessageInnerMessage$Ref =
+  builder.objectRef<PrefixedMessage_InnerMessage>(
+    "PrefixedMessageInnerMessage",
+  );
 builder.objectType(PrefixedMessageInnerMessage$Ref, {
   name: "PrefixedMessageInnerMessage",
   fields: (t) => ({
@@ -257,9 +262,11 @@ builder.objectType(PrefixedMessageInnerMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as PrefixedMessage_InnerMessage | { $type: string & {}; })
-      .$type ===
-      "testapis.options.message_and_field.PrefixedMessage.InnerMessage";
+    return (
+      (source as PrefixedMessage_InnerMessage | { $type: string & {} })
+        .$type ===
+      "testapis.options.message_and_field.PrefixedMessage.InnerMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -271,9 +278,10 @@ builder.objectType(PrefixedMessageInnerMessage$Ref, {
   },
 });
 
-export const PrefixedMessageInnerMessage2$Ref = builder.objectRef<
-  PrefixedMessage_InnerMessage2
->("PrefixedMessageInnerMessage2");
+export const PrefixedMessageInnerMessage2$Ref =
+  builder.objectRef<PrefixedMessage_InnerMessage2>(
+    "PrefixedMessageInnerMessage2",
+  );
 builder.objectType(PrefixedMessageInnerMessage2$Ref, {
   name: "PrefixedMessageInnerMessage2",
   fields: (t) => ({
@@ -289,9 +297,11 @@ builder.objectType(PrefixedMessageInnerMessage2$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as PrefixedMessage_InnerMessage2 | { $type: string & {}; })
-      .$type ===
-      "testapis.options.message_and_field.PrefixedMessage.InnerMessage2";
+    return (
+      (source as PrefixedMessage_InnerMessage2 | { $type: string & {} })
+        .$type ===
+      "testapis.options.message_and_field.PrefixedMessage.InnerMessage2"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -303,9 +313,8 @@ builder.objectType(PrefixedMessageInnerMessage2$Ref, {
   },
 });
 
-export const IgnoredMessageNotIgnored$Ref = builder.objectRef<
-  IgnoredMessage_NotIgnored
->("IgnoredMessageNotIgnored");
+export const IgnoredMessageNotIgnored$Ref =
+  builder.objectRef<IgnoredMessage_NotIgnored>("IgnoredMessageNotIgnored");
 builder.objectType(IgnoredMessageNotIgnored$Ref, {
   name: "IgnoredMessageNotIgnored",
   fields: (t) => ({
@@ -316,8 +325,10 @@ builder.objectType(IgnoredMessageNotIgnored$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as IgnoredMessage_NotIgnored | { $type: string & {}; })
-      .$type === "testapis.options.message_and_field.IgnoredMessage.NotIgnored";
+    return (
+      (source as IgnoredMessage_NotIgnored | { $type: string & {} }).$type ===
+      "testapis.options.message_and_field.IgnoredMessage.NotIgnored"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -342,133 +353,135 @@ export type PrefixedMessageInput$Shape = {
   squashedMessages?: Array<PrefixedMessageSquashedMessageInput$Shape> | null;
 };
 
-export const PrefixedMessageInput$Ref: InputObjectRef<
-  PrefixedMessageInput$Shape
-> = builder.inputRef<PrefixedMessageInput$Shape>("PrefixedMessageInput")
-  .implement({
-    fields: (t) => ({
-      id: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "id",
-            typeFullName: "uint64",
-            options: { "[graphql.field]": { id: true } },
+export const PrefixedMessageInput$Ref: InputObjectRef<PrefixedMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInput$Shape>("PrefixedMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "id",
+              typeFullName: "uint64",
+              options: { "[graphql.field]": { id: true } },
+            },
           },
-        },
-      }),
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      prefixedEnum: t.field({
-        type: PrefixedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "prefixed_enum",
-            typeFullName: "testapis.options.message_and_field.PrefixedEnum",
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
-      }),
-      thisFieldWasRenamed: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "this_field_will_be_renamed",
-            typeFullName: "string",
-            options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
+        }),
+        prefixedEnum: t.field({
+          type: PrefixedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "prefixed_enum",
+              typeFullName: "testapis.options.message_and_field.PrefixedEnum",
+            },
           },
-        },
-      }),
-      skipResolver: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "skip_resolver",
-            typeFullName: "string",
-            options: { "[graphql.field]": { skipResolver: true } },
+        }),
+        thisFieldWasRenamed: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "this_field_will_be_renamed",
+              typeFullName: "string",
+              options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
+            },
           },
-        },
-      }),
-      squashedMessage: t.field({
-        type: PrefixedMessageSquashedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "squashed_message",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+        }),
+        skipResolver: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "skip_resolver",
+              typeFullName: "string",
+              options: { "[graphql.field]": { skipResolver: true } },
+            },
           },
-        },
-      }),
-      renamedMessage: t.field({
-        type: RenamedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "renamed_message",
-            typeFullName:
-              "testapis.options.message_and_field.MessageWillRename",
+        }),
+        squashedMessage: t.field({
+          type: PrefixedMessageSquashedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "squashed_message",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
           },
-        },
-      }),
-      renamedEnum: t.field({
-        type: RenamedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "renamed_enum",
-            typeFullName: "testapis.options.message_and_field.EnumWillRename",
+        }),
+        renamedMessage: t.field({
+          type: RenamedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_message",
+              typeFullName:
+                "testapis.options.message_and_field.MessageWillRename",
+            },
           },
-        },
-      }),
-      notIgnoredMessage: t.field({
-        type: IgnoredMessageNotIgnoredInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "not_ignored_message",
-            typeFullName:
-              "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+        }),
+        renamedEnum: t.field({
+          type: RenamedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_enum",
+              typeFullName: "testapis.options.message_and_field.EnumWillRename",
+            },
           },
-        },
-      }),
-      oneofNotIgnoredField: t.field({
-        type: PrefixedMessageInnerMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "oneof_not_ignored_field",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+        }),
+        notIgnoredMessage: t.field({
+          type: IgnoredMessageNotIgnoredInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "not_ignored_message",
+              typeFullName:
+                "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+            },
           },
-        },
-      }),
-      squashedMessages: t.field({
-        type: [PrefixedMessageSquashedMessageInput$Ref],
-        required: { list: false, items: true },
-        extensions: {
-          protobufField: {
-            name: "squashed_messages",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+        }),
+        oneofNotIgnoredField: t.field({
+          type: PrefixedMessageInnerMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_not_ignored_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
           },
-        },
+        }),
+        squashedMessages: t.field({
+          type: [PrefixedMessageSquashedMessageInput$Ref],
+          required: { list: false, items: true },
+          extensions: {
+            protobufField: {
+              name: "squashed_messages",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.PrefixedMessage",
-        name: "PrefixedMessage",
-        package: "testapis.options.message_and_field",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.PrefixedMessage",
+          name: "PrefixedMessage",
+          package: "testapis.options.message_and_field",
+        },
       },
-    },
-  });
+    });
 
 export type PrefixedMessagePartialInput$Shape = {
   id?: PrefixedMessage["id"] | null;
@@ -481,508 +494,537 @@ export type PrefixedMessagePartialInput$Shape = {
   renamedEnum?: PrefixedMessage["renamedEnum"] | null;
   notIgnoredMessage?: IgnoredMessageNotIgnoredPartialInput$Shape | null;
   oneofNotIgnoredField?: PrefixedMessageInnerMessagePartialInput$Shape | null;
-  squashedMessages?:
-    | Array<PrefixedMessageSquashedMessagePartialInput$Shape>
-    | null;
+  squashedMessages?: Array<PrefixedMessageSquashedMessagePartialInput$Shape> | null;
 };
 
-export const PrefixedMessagePartialInput$Ref: InputObjectRef<
-  PrefixedMessagePartialInput$Shape
-> = builder.inputRef<PrefixedMessagePartialInput$Shape>(
-  "PrefixedMessagePartialInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "id",
-          typeFullName: "uint64",
-          options: { "[graphql.field]": { id: true } },
-        },
-      },
-    }),
-    body: t.field({
-      type: "String",
-      required: false,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-    prefixedEnum: t.field({
-      type: PrefixedEnum$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "prefixed_enum",
-          typeFullName: "testapis.options.message_and_field.PrefixedEnum",
-        },
-      },
-    }),
-    thisFieldWasRenamed: t.field({
-      type: "String",
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "this_field_will_be_renamed",
-          typeFullName: "string",
-          options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
-        },
-      },
-    }),
-    skipResolver: t.field({
-      type: "String",
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "skip_resolver",
-          typeFullName: "string",
-          options: { "[graphql.field]": { skipResolver: true } },
-        },
-      },
-    }),
-    squashedMessage: t.field({
-      type: PrefixedMessageSquashedMessagePartialInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "squashed_message",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
-        },
-      },
-    }),
-    renamedMessage: t.field({
-      type: RenamedMessagePartialInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "renamed_message",
-          typeFullName: "testapis.options.message_and_field.MessageWillRename",
-        },
-      },
-    }),
-    renamedEnum: t.field({
-      type: RenamedEnum$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "renamed_enum",
-          typeFullName: "testapis.options.message_and_field.EnumWillRename",
-        },
-      },
-    }),
-    notIgnoredMessage: t.field({
-      type: IgnoredMessageNotIgnoredPartialInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "not_ignored_message",
-          typeFullName:
-            "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
-        },
-      },
-    }),
-    oneofNotIgnoredField: t.field({
-      type: PrefixedMessageInnerMessagePartialInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "oneof_not_ignored_field",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-        },
-      },
-    }),
-    squashedMessages: t.field({
-      type: [PrefixedMessageSquashedMessagePartialInput$Ref],
-      required: { list: false, items: true },
-      extensions: {
-        protobufField: {
-          name: "squashed_messages",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.message_and_field.PrefixedMessage",
-      name: "PrefixedMessage",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
-
-export type RenamedMessageInput$Shape = { body: MessageWillRename["body"]; };
-
-export const RenamedMessageInput$Ref: InputObjectRef<
-  RenamedMessageInput$Shape
-> = builder.inputRef<RenamedMessageInput$Shape>("RenamedMessageInput")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const PrefixedMessagePartialInput$Ref: InputObjectRef<PrefixedMessagePartialInput$Shape> =
+  builder
+    .inputRef<PrefixedMessagePartialInput$Shape>("PrefixedMessagePartialInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "id",
+              typeFullName: "uint64",
+              options: { "[graphql.field]": { id: true } },
+            },
+          },
+        }),
+        body: t.field({
+          type: "String",
+          required: false,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+        prefixedEnum: t.field({
+          type: PrefixedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "prefixed_enum",
+              typeFullName: "testapis.options.message_and_field.PrefixedEnum",
+            },
+          },
+        }),
+        thisFieldWasRenamed: t.field({
+          type: "String",
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "this_field_will_be_renamed",
+              typeFullName: "string",
+              options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
+            },
+          },
+        }),
+        skipResolver: t.field({
+          type: "String",
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "skip_resolver",
+              typeFullName: "string",
+              options: { "[graphql.field]": { skipResolver: true } },
+            },
+          },
+        }),
+        squashedMessage: t.field({
+          type: PrefixedMessageSquashedMessagePartialInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "squashed_message",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
+          },
+        }),
+        renamedMessage: t.field({
+          type: RenamedMessagePartialInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_message",
+              typeFullName:
+                "testapis.options.message_and_field.MessageWillRename",
+            },
+          },
+        }),
+        renamedEnum: t.field({
+          type: RenamedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_enum",
+              typeFullName: "testapis.options.message_and_field.EnumWillRename",
+            },
+          },
+        }),
+        notIgnoredMessage: t.field({
+          type: IgnoredMessageNotIgnoredPartialInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "not_ignored_message",
+              typeFullName:
+                "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+            },
+          },
+        }),
+        oneofNotIgnoredField: t.field({
+          type: PrefixedMessageInnerMessagePartialInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_not_ignored_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
+          },
+        }),
+        squashedMessages: t.field({
+          type: [PrefixedMessageSquashedMessagePartialInput$Ref],
+          required: { list: false, items: true },
+          extensions: {
+            protobufField: {
+              name: "squashed_messages",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.MessageWillRename",
-        name: "MessageWillRename",
-        package: "testapis.options.message_and_field",
-        options: { "[graphql.object_type]": { name: "RenamedMessage" } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.PrefixedMessage",
+          name: "PrefixedMessage",
+          package: "testapis.options.message_and_field",
+        },
       },
-    },
-  });
+    });
+
+export type RenamedMessageInput$Shape = {
+  body: MessageWillRename["body"];
+};
+
+export const RenamedMessageInput$Ref: InputObjectRef<RenamedMessageInput$Shape> =
+  builder
+    .inputRef<RenamedMessageInput$Shape>("RenamedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.MessageWillRename",
+          name: "MessageWillRename",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { name: "RenamedMessage" } },
+        },
+      },
+    });
 
 export type RenamedMessagePartialInput$Shape = {
   body?: MessageWillRename["body"] | null;
 };
 
-export const RenamedMessagePartialInput$Ref: InputObjectRef<
-  RenamedMessagePartialInput$Shape
-> = builder.inputRef<RenamedMessagePartialInput$Shape>(
-  "RenamedMessagePartialInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.message_and_field.MessageWillRename",
-      name: "MessageWillRename",
-      package: "testapis.options.message_and_field",
-      options: { "[graphql.object_type]": { name: "RenamedMessage" } },
-    },
-  },
-});
-
-export type InterfaceMessageInput$Shape = { id: InterfaceMessage["id"]; };
-
-export const InterfaceMessageInput$Ref: InputObjectRef<
-  InterfaceMessageInput$Shape
-> = builder.inputRef<InterfaceMessageInput$Shape>("InterfaceMessageInput")
-  .implement({
-    fields: (t) => ({
-      id: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+export const RenamedMessagePartialInput$Ref: InputObjectRef<RenamedMessagePartialInput$Shape> =
+  builder
+    .inputRef<RenamedMessagePartialInput$Shape>("RenamedMessagePartialInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.InterfaceMessage",
-        name: "InterfaceMessage",
-        package: "testapis.options.message_and_field",
-        options: { "[graphql.object_type]": { interface: true } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.MessageWillRename",
+          name: "MessageWillRename",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { name: "RenamedMessage" } },
+        },
       },
-    },
-  });
+    });
+
+export type InterfaceMessageInput$Shape = {
+  id: InterfaceMessage["id"];
+};
+
+export const InterfaceMessageInput$Ref: InputObjectRef<InterfaceMessageInput$Shape> =
+  builder
+    .inputRef<InterfaceMessageInput$Shape>("InterfaceMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.InterfaceMessage",
+          name: "InterfaceMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { interface: true } },
+        },
+      },
+    });
 
 export type InterfaceMessagePartialInput$Shape = {
   id?: InterfaceMessage["id"] | null;
 };
 
-export const InterfaceMessagePartialInput$Ref: InputObjectRef<
-  InterfaceMessagePartialInput$Shape
-> = builder.inputRef<InterfaceMessagePartialInput$Shape>(
-  "InterfaceMessagePartialInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: false,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.message_and_field.InterfaceMessage",
-      name: "InterfaceMessage",
-      package: "testapis.options.message_and_field",
-      options: { "[graphql.object_type]": { interface: true } },
-    },
-  },
-});
+export const InterfaceMessagePartialInput$Ref: InputObjectRef<InterfaceMessagePartialInput$Shape> =
+  builder
+    .inputRef<InterfaceMessagePartialInput$Shape>(
+      "InterfaceMessagePartialInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: false,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.InterfaceMessage",
+          name: "InterfaceMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { interface: true } },
+        },
+      },
+    });
 
 export type PrefixedMessageInnerMessageInput$Shape = {
   id: PrefixedMessage_InnerMessage["id"];
   body: PrefixedMessage_InnerMessage["body"];
 };
 
-export const PrefixedMessageInnerMessageInput$Ref: InputObjectRef<
-  PrefixedMessageInnerMessageInput$Shape
-> = builder.inputRef<PrefixedMessageInnerMessageInput$Shape>(
-  "PrefixedMessageInnerMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-      name: "InnerMessage",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const PrefixedMessageInnerMessageInput$Ref: InputObjectRef<PrefixedMessageInnerMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessageInput$Shape>(
+      "PrefixedMessageInnerMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+          name: "InnerMessage",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export type PrefixedMessageInnerMessagePartialInput$Shape = {
   id?: PrefixedMessage_InnerMessage["id"] | null;
   body?: PrefixedMessage_InnerMessage["body"] | null;
 };
 
-export const PrefixedMessageInnerMessagePartialInput$Ref: InputObjectRef<
-  PrefixedMessageInnerMessagePartialInput$Shape
-> = builder.inputRef<PrefixedMessageInnerMessagePartialInput$Shape>(
-  "PrefixedMessageInnerMessagePartialInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: false,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: false,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-      name: "InnerMessage",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const PrefixedMessageInnerMessagePartialInput$Ref: InputObjectRef<PrefixedMessageInnerMessagePartialInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessagePartialInput$Shape>(
+      "PrefixedMessageInnerMessagePartialInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: false,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: false,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+          name: "InnerMessage",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export type PrefixedMessageInnerMessage2Input$Shape = {
   id: PrefixedMessage_InnerMessage2["id"];
   body: PrefixedMessage_InnerMessage2["body"];
 };
 
-export const PrefixedMessageInnerMessage2Input$Ref: InputObjectRef<
-  PrefixedMessageInnerMessage2Input$Shape
-> = builder.inputRef<PrefixedMessageInnerMessage2Input$Shape>(
-  "PrefixedMessageInnerMessage2Input",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-      name: "InnerMessage2",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const PrefixedMessageInnerMessage2Input$Ref: InputObjectRef<PrefixedMessageInnerMessage2Input$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessage2Input$Shape>(
+      "PrefixedMessageInnerMessage2Input",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+          name: "InnerMessage2",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export type PrefixedMessageInnerMessage2PartialInput$Shape = {
   id?: PrefixedMessage_InnerMessage2["id"] | null;
   body?: PrefixedMessage_InnerMessage2["body"] | null;
 };
 
-export const PrefixedMessageInnerMessage2PartialInput$Ref: InputObjectRef<
-  PrefixedMessageInnerMessage2PartialInput$Shape
-> = builder.inputRef<PrefixedMessageInnerMessage2PartialInput$Shape>(
-  "PrefixedMessageInnerMessage2PartialInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: false,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: false,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-      name: "InnerMessage2",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const PrefixedMessageInnerMessage2PartialInput$Ref: InputObjectRef<PrefixedMessageInnerMessage2PartialInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessage2PartialInput$Shape>(
+      "PrefixedMessageInnerMessage2PartialInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: false,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: false,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+          name: "InnerMessage2",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export type PrefixedMessageSquashedMessageInput$Shape = {
   oneofField?: PrefixedMessageInnerMessageInput$Shape | null;
   oneofField2?: PrefixedMessageInnerMessage2Input$Shape | null;
 };
 
-export const PrefixedMessageSquashedMessageInput$Ref: InputObjectRef<
-  PrefixedMessageSquashedMessageInput$Shape
-> = builder.inputRef<PrefixedMessageSquashedMessageInput$Shape>(
-  "PrefixedMessageSquashedMessageInput",
-).implement({
-  fields: (t) => ({
-    oneofField: t.field({
-      type: PrefixedMessageInnerMessageInput$Ref,
-      required: false,
+export const PrefixedMessageSquashedMessageInput$Ref: InputObjectRef<PrefixedMessageSquashedMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageSquashedMessageInput$Shape>(
+      "PrefixedMessageSquashedMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        oneofField: t.field({
+          type: PrefixedMessageInnerMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
+          },
+        }),
+        oneofField2: t.field({
+          type: PrefixedMessageInnerMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field_2",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "oneof_field",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+          name: "SquashedMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { squashUnion: true } },
         },
       },
-    }),
-    oneofField2: t.field({
-      type: PrefixedMessageInnerMessage2Input$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "oneof_field_2",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
-      name: "SquashedMessage",
-      package: "testapis.options.message_and_field",
-      options: { "[graphql.object_type]": { squashUnion: true } },
-    },
-  },
-});
+    });
 
 export type PrefixedMessageSquashedMessagePartialInput$Shape = {
   oneofField?: PrefixedMessageInnerMessagePartialInput$Shape | null;
   oneofField2?: PrefixedMessageInnerMessage2PartialInput$Shape | null;
 };
 
-export const PrefixedMessageSquashedMessagePartialInput$Ref: InputObjectRef<
-  PrefixedMessageSquashedMessagePartialInput$Shape
-> = builder.inputRef<PrefixedMessageSquashedMessagePartialInput$Shape>(
-  "PrefixedMessageSquashedMessagePartialInput",
-).implement({
-  fields: (t) => ({
-    oneofField: t.field({
-      type: PrefixedMessageInnerMessagePartialInput$Ref,
-      required: false,
+export const PrefixedMessageSquashedMessagePartialInput$Ref: InputObjectRef<PrefixedMessageSquashedMessagePartialInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageSquashedMessagePartialInput$Shape>(
+      "PrefixedMessageSquashedMessagePartialInput",
+    )
+    .implement({
+      fields: (t) => ({
+        oneofField: t.field({
+          type: PrefixedMessageInnerMessagePartialInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
+          },
+        }),
+        oneofField2: t.field({
+          type: PrefixedMessageInnerMessage2PartialInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field_2",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "oneof_field",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+          name: "SquashedMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { squashUnion: true } },
         },
       },
-    }),
-    oneofField2: t.field({
-      type: PrefixedMessageInnerMessage2PartialInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "oneof_field_2",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
-      name: "SquashedMessage",
-      package: "testapis.options.message_and_field",
-      options: { "[graphql.object_type]": { squashUnion: true } },
-    },
-  },
-});
+    });
 
 export type IgnoredMessageNotIgnoredInput$Shape = {
   body: IgnoredMessage_NotIgnored["body"];
 };
 
-export const IgnoredMessageNotIgnoredInput$Ref: InputObjectRef<
-  IgnoredMessageNotIgnoredInput$Shape
-> = builder.inputRef<IgnoredMessageNotIgnoredInput$Shape>(
-  "IgnoredMessageNotIgnoredInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
-      name: "NotIgnored",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const IgnoredMessageNotIgnoredInput$Ref: InputObjectRef<IgnoredMessageNotIgnoredInput$Shape> =
+  builder
+    .inputRef<IgnoredMessageNotIgnoredInput$Shape>(
+      "IgnoredMessageNotIgnoredInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+          name: "NotIgnored",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export type IgnoredMessageNotIgnoredPartialInput$Shape = {
   body?: IgnoredMessage_NotIgnored["body"] | null;
 };
 
-export const IgnoredMessageNotIgnoredPartialInput$Ref: InputObjectRef<
-  IgnoredMessageNotIgnoredPartialInput$Shape
-> = builder.inputRef<IgnoredMessageNotIgnoredPartialInput$Shape>(
-  "IgnoredMessageNotIgnoredPartialInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
-      name: "NotIgnored",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const IgnoredMessageNotIgnoredPartialInput$Ref: InputObjectRef<IgnoredMessageNotIgnoredPartialInput$Shape> =
+  builder
+    .inputRef<IgnoredMessageNotIgnoredPartialInput$Shape>(
+      "IgnoredMessageNotIgnoredPartialInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+          name: "NotIgnored",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
-export const InterfaceMessage$Ref = builder.interfaceRef<
-  Pick<InterfaceMessage, "id">
->("InterfaceMessage");
+export const InterfaceMessage$Ref =
+  builder.interfaceRef<Pick<InterfaceMessage, "id">>("InterfaceMessage");
 builder.interfaceType(InterfaceMessage$Ref, {
   name: "InterfaceMessage",
   fields: (t) => ({
@@ -1012,17 +1054,18 @@ export const PrefixedMessageSquashedMessage$Ref = builder.unionType(
           "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
         name: "SquashedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }, {
-          name: "oneof_field_2",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }],
+        fields: [
+          {
+            name: "oneof_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+          {
+            name: "oneof_field_2",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+        ],
       },
     },
   },
@@ -1039,18 +1082,19 @@ export const PrefixedMessagePartialIgnoreOneof$Ref = builder.unionType(
         name: "partial_ignore_oneof",
         messageName: "PrefixedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_not_ignored_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-        }],
+        fields: [
+          {
+            name: "oneof_not_ignored_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+          },
+        ],
       },
     },
   },
 );
 
-export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> = builder
-  .enumType("RenamedEnum", {
+export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> =
+  builder.enumType("RenamedEnum", {
     values: {
       FOO: {
         value: 1,
@@ -1071,8 +1115,8 @@ export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> = builder
     },
   });
 
-export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> = builder
-  .enumType("PrefixedEnum", {
+export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> =
+  builder.enumType("PrefixedEnum", {
     values: {
       PREFIXED_FOO: {
         value: 1,

--- a/tests/golden/ts-proto/testapis.basic.empty/__expected__/testapis/basic/empty/empty.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.basic.empty/__expected__/testapis/basic/empty/empty.pb.pothos.ts
@@ -18,8 +18,10 @@ builder.objectType(EmptyMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as EmptyMessage | { $type: string & {}; }).$type ===
-      "testapis.basic.empty.EmptyMessage";
+    return (
+      (source as EmptyMessage | { $type: string & {} }).$type ===
+      "testapis.basic.empty.EmptyMessage"
+    );
   },
   extensions: {
     protobufMessage: {

--- a/tests/golden/ts-proto/testapis.basic.enums/__expected__/testapis/basic/enums/enums.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.basic.enums/__expected__/testapis/basic/enums/enums.pb.pothos.ts
@@ -10,9 +10,8 @@ import {
 } from "@proto-graphql/e2e-testapis-ts-proto/lib/testapis/basic/enums/enums";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const MessageWithEnums$Ref = builder.objectRef<MessageWithEnums>(
-  "MessageWithEnums",
-);
+export const MessageWithEnums$Ref =
+  builder.objectRef<MessageWithEnums>("MessageWithEnums");
 builder.objectType(MessageWithEnums$Ref, {
   name: "MessageWithEnums",
   fields: (t) => ({
@@ -156,8 +155,10 @@ builder.objectType(MessageWithEnums$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as MessageWithEnums | { $type: string & {}; }).$type ===
-      "testapis.basic.enums.MessageWithEnums";
+    return (
+      (source as MessageWithEnums | { $type: string & {} }).$type ===
+      "testapis.basic.enums.MessageWithEnums"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -171,122 +172,120 @@ builder.objectType(MessageWithEnums$Ref, {
 export type MessageWithEnumsInput$Shape = {
   requiredMyEnum: MessageWithEnums["requiredMyEnum"];
   optionalMyEnum?: MessageWithEnums["optionalMyEnum"] | null;
-  requiredMyEnumWithoutUnspecified:
-    MessageWithEnums["requiredMyEnumWithoutUnspecified"];
+  requiredMyEnumWithoutUnspecified: MessageWithEnums["requiredMyEnumWithoutUnspecified"];
   optionalMyEnumWithoutUnspecified?:
     | MessageWithEnums["optionalMyEnumWithoutUnspecified"]
     | null;
   requiredMyEnums: MessageWithEnums["requiredMyEnums"];
   optionalMyEnums?: MessageWithEnums["optionalMyEnums"] | null;
-  requiredMyEnumWithoutUnspecifieds:
-    MessageWithEnums["requiredMyEnumWithoutUnspecifieds"];
+  requiredMyEnumWithoutUnspecifieds: MessageWithEnums["requiredMyEnumWithoutUnspecifieds"];
   optionalMyEnumWithoutUnspecifieds?:
     | MessageWithEnums["optionalMyEnumWithoutUnspecifieds"]
     | null;
 };
 
-export const MessageWithEnumsInput$Ref: InputObjectRef<
-  MessageWithEnumsInput$Shape
-> = builder.inputRef<MessageWithEnumsInput$Shape>("MessageWithEnumsInput")
-  .implement({
-    fields: (t) => ({
-      requiredMyEnum: t.field({
-        type: MyEnum$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enum",
-            typeFullName: "testapis.basic.enums.MyEnum",
+export const MessageWithEnumsInput$Ref: InputObjectRef<MessageWithEnumsInput$Shape> =
+  builder
+    .inputRef<MessageWithEnumsInput$Shape>("MessageWithEnumsInput")
+    .implement({
+      fields: (t) => ({
+        requiredMyEnum: t.field({
+          type: MyEnum$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enum",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      optionalMyEnum: t.field({
-        type: MyEnum$Ref,
-        required: false,
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enum",
-            typeFullName: "testapis.basic.enums.MyEnum",
+        }),
+        optionalMyEnum: t.field({
+          type: MyEnum$Ref,
+          required: false,
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enum",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      requiredMyEnumWithoutUnspecified: t.field({
-        type: MyEnumWithoutUnspecified$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enum_without_unspecified",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        requiredMyEnumWithoutUnspecified: t.field({
+          type: MyEnumWithoutUnspecified$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enum_without_unspecified",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
-      }),
-      optionalMyEnumWithoutUnspecified: t.field({
-        type: MyEnumWithoutUnspecified$Ref,
-        required: false,
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enum_without_unspecified",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        optionalMyEnumWithoutUnspecified: t.field({
+          type: MyEnumWithoutUnspecified$Ref,
+          required: false,
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enum_without_unspecified",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
-      }),
-      requiredMyEnums: t.field({
-        type: [MyEnum$Ref],
-        required: { list: true, items: true },
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enums",
-            typeFullName: "testapis.basic.enums.MyEnum",
+        }),
+        requiredMyEnums: t.field({
+          type: [MyEnum$Ref],
+          required: { list: true, items: true },
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enums",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      optionalMyEnums: t.field({
-        type: [MyEnum$Ref],
-        required: { list: false, items: true },
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enums",
-            typeFullName: "testapis.basic.enums.MyEnum",
+        }),
+        optionalMyEnums: t.field({
+          type: [MyEnum$Ref],
+          required: { list: false, items: true },
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enums",
+              typeFullName: "testapis.basic.enums.MyEnum",
+            },
           },
-        },
-      }),
-      requiredMyEnumWithoutUnspecifieds: t.field({
-        type: [MyEnumWithoutUnspecified$Ref],
-        required: { list: true, items: true },
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "required_my_enum_without_unspecifieds",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        requiredMyEnumWithoutUnspecifieds: t.field({
+          type: [MyEnumWithoutUnspecified$Ref],
+          required: { list: true, items: true },
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_my_enum_without_unspecifieds",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
-      }),
-      optionalMyEnumWithoutUnspecifieds: t.field({
-        type: [MyEnumWithoutUnspecified$Ref],
-        required: { list: false, items: true },
-        description: "Optional.",
-        extensions: {
-          protobufField: {
-            name: "optional_my_enum_without_unspecifieds",
-            typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+        }),
+        optionalMyEnumWithoutUnspecifieds: t.field({
+          type: [MyEnumWithoutUnspecified$Ref],
+          required: { list: false, items: true },
+          description: "Optional.",
+          extensions: {
+            protobufField: {
+              name: "optional_my_enum_without_unspecifieds",
+              typeFullName: "testapis.basic.enums.MyEnumWithoutUnspecified",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.enums.MessageWithEnums",
-        name: "MessageWithEnums",
-        package: "testapis.basic.enums",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.enums.MessageWithEnums",
+          name: "MessageWithEnums",
+          package: "testapis.basic.enums",
+        },
       },
-    },
-  });
+    });
 
 export const MyEnum$Ref: EnumRef<MyEnum, MyEnum> = builder.enumType("MyEnum", {
   values: {

--- a/tests/golden/ts-proto/testapis.basic.nested/__expected__/testapis/basic/nested/nested.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.basic.nested/__expected__/testapis/basic/nested/nested.pb.pothos.ts
@@ -10,9 +10,8 @@ import {
 } from "@proto-graphql/e2e-testapis-ts-proto/lib/testapis/basic/nested/nested";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const ParentMessage$Ref = builder.objectRef<ParentMessage>(
-  "ParentMessage",
-);
+export const ParentMessage$Ref =
+  builder.objectRef<ParentMessage>("ParentMessage");
 builder.objectType(ParentMessage$Ref, {
   name: "ParentMessage",
   fields: (t) => ({
@@ -52,8 +51,10 @@ builder.objectType(ParentMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as ParentMessage | { $type: string & {}; }).$type ===
-      "testapis.basic.nested.ParentMessage";
+    return (
+      (source as ParentMessage | { $type: string & {} }).$type ===
+      "testapis.basic.nested.ParentMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -64,9 +65,8 @@ builder.objectType(ParentMessage$Ref, {
   },
 });
 
-export const ParentMessageNestedMessage$Ref = builder.objectRef<
-  ParentMessage_NestedMessage
->("ParentMessageNestedMessage");
+export const ParentMessageNestedMessage$Ref =
+  builder.objectRef<ParentMessage_NestedMessage>("ParentMessageNestedMessage");
 builder.objectType(ParentMessageNestedMessage$Ref, {
   name: "ParentMessageNestedMessage",
   fields: (t) => ({
@@ -79,8 +79,10 @@ builder.objectType(ParentMessageNestedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as ParentMessage_NestedMessage | { $type: string & {}; })
-      .$type === "testapis.basic.nested.ParentMessage.NestedMessage";
+    return (
+      (source as ParentMessage_NestedMessage | { $type: string & {} }).$type ===
+      "testapis.basic.nested.ParentMessage.NestedMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -98,69 +100,74 @@ export type ParentMessageInput$Shape = {
 };
 
 export const ParentMessageInput$Ref: InputObjectRef<ParentMessageInput$Shape> =
-  builder.inputRef<ParentMessageInput$Shape>("ParentMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      nested: t.field({
-        type: ParentMessageNestedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "nested",
-            typeFullName: "testapis.basic.nested.ParentMessage.NestedMessage",
+  builder
+    .inputRef<ParentMessageInput$Shape>("ParentMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
-      }),
-      nestedEnum: t.field({
-        type: ParentMessageNestedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "nested_enum",
-            typeFullName: "testapis.basic.nested.ParentMessage.NestedEnum",
+        }),
+        nested: t.field({
+          type: ParentMessageNestedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "nested",
+              typeFullName: "testapis.basic.nested.ParentMessage.NestedMessage",
+            },
           },
-        },
+        }),
+        nestedEnum: t.field({
+          type: ParentMessageNestedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "nested_enum",
+              typeFullName: "testapis.basic.nested.ParentMessage.NestedEnum",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.nested.ParentMessage",
-        name: "ParentMessage",
-        package: "testapis.basic.nested",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.nested.ParentMessage",
+          name: "ParentMessage",
+          package: "testapis.basic.nested",
+        },
       },
-    },
-  });
+    });
 
 export type ParentMessageNestedMessageInput$Shape = {
   nestedBody: ParentMessage_NestedMessage["nestedBody"];
 };
 
-export const ParentMessageNestedMessageInput$Ref: InputObjectRef<
-  ParentMessageNestedMessageInput$Shape
-> = builder.inputRef<ParentMessageNestedMessageInput$Shape>(
-  "ParentMessageNestedMessageInput",
-).implement({
-  fields: (t) => ({
-    nestedBody: t.field({
-      type: "String",
-      required: true,
+export const ParentMessageNestedMessageInput$Ref: InputObjectRef<ParentMessageNestedMessageInput$Shape> =
+  builder
+    .inputRef<ParentMessageNestedMessageInput$Shape>(
+      "ParentMessageNestedMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        nestedBody: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "nested_body", typeFullName: "string" },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: { name: "nested_body", typeFullName: "string" },
+        protobufMessage: {
+          fullName: "testapis.basic.nested.ParentMessage.NestedMessage",
+          name: "NestedMessage",
+          package: "testapis.basic.nested",
+        },
       },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.basic.nested.ParentMessage.NestedMessage",
-      name: "NestedMessage",
-      package: "testapis.basic.nested",
-    },
-  },
-});
+    });
 
 export const ParentMessageNestedEnum$Ref: EnumRef<
   ParentMessage_NestedEnum,

--- a/tests/golden/ts-proto/testapis.basic.presence/__expected__/testapis/basic/presence/presence.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.basic.presence/__expected__/testapis/basic/presence/presence.pb.pothos.ts
@@ -45,8 +45,10 @@ builder.objectType(Message$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Message | { $type: string & {}; }).$type ===
-      "testapis.basic.presence.Message";
+    return (
+      (source as Message | { $type: string & {} }).$type ===
+      "testapis.basic.presence.Message"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -57,9 +59,8 @@ builder.objectType(Message$Ref, {
   },
 });
 
-export const NestedMessage$Ref = builder.objectRef<NestedMessage>(
-  "NestedMessage",
-);
+export const NestedMessage$Ref =
+  builder.objectRef<NestedMessage>("NestedMessage");
 builder.objectType(NestedMessage$Ref, {
   name: "NestedMessage",
   fields: (t) => ({
@@ -70,8 +71,10 @@ builder.objectType(NestedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as NestedMessage | { $type: string & {}; }).$type ===
-      "testapis.basic.presence.NestedMessage";
+    return (
+      (source as NestedMessage | { $type: string & {} }).$type ===
+      "testapis.basic.presence.NestedMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -89,7 +92,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredStringValue: t.field({
         type: "String",
@@ -131,22 +135,28 @@ export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
     },
   });
 
-export type NestedMessageInput$Shape = { body: NestedMessage["body"]; };
+export type NestedMessageInput$Shape = {
+  body: NestedMessage["body"];
+};
 
 export const NestedMessageInput$Ref: InputObjectRef<NestedMessageInput$Shape> =
-  builder.inputRef<NestedMessageInput$Shape>("NestedMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<NestedMessageInput$Shape>("NestedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.presence.NestedMessage",
-        name: "NestedMessage",
-        package: "testapis.basic.presence",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.presence.NestedMessage",
+          name: "NestedMessage",
+          package: "testapis.basic.presence",
+        },
       },
-    },
-  });
+    });

--- a/tests/golden/ts-proto/testapis.basic.scalars/__expected__/testapis/basic/scalars/scalars.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.basic.scalars/__expected__/testapis/basic/scalars/scalars.pb.pothos.ts
@@ -65,8 +65,10 @@ builder.objectType(Message$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Message | { $type: string & {}; }).$type ===
-      "testapis.basic.scalars.Message";
+    return (
+      (source as Message | { $type: string & {} }).$type ===
+      "testapis.basic.scalars.Message"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -359,8 +361,10 @@ builder.objectType(Primitives$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Primitives | { $type: string & {}; }).$type ===
-      "testapis.basic.scalars.Primitives";
+    return (
+      (source as Primitives | { $type: string & {} }).$type ===
+      "testapis.basic.scalars.Primitives"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -379,7 +383,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       requiredPrimitives: t.field({
         type: PrimitivesInput$Ref,
@@ -469,308 +474,316 @@ export type PrimitivesInput$Shape = {
 };
 
 export const PrimitivesInput$Ref: InputObjectRef<PrimitivesInput$Shape> =
-  builder.inputRef<PrimitivesInput$Shape>("PrimitivesInput").implement({
-    fields: (t) => ({
-      requiredDoubleValue: t.field({
-        type: "Float",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_double_value",
-            typeFullName: "double",
+  builder
+    .inputRef<PrimitivesInput$Shape>("PrimitivesInput")
+    .implement({
+      fields: (t) => ({
+        requiredDoubleValue: t.field({
+          type: "Float",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_double_value",
+              typeFullName: "double",
+            },
           },
-        },
-      }),
-      requiredFloatValue: t.field({
-        type: "Float",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_float_value",
-            typeFullName: "float",
+        }),
+        requiredFloatValue: t.field({
+          type: "Float",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_float_value",
+              typeFullName: "float",
+            },
           },
-        },
-      }),
-      requiredInt32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_int32_value",
-            typeFullName: "int32",
+        }),
+        requiredInt32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_int32_value",
+              typeFullName: "int32",
+            },
           },
-        },
-      }),
-      requiredInt64Value: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_int64_value",
-            typeFullName: "int64",
+        }),
+        requiredInt64Value: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_int64_value",
+              typeFullName: "int64",
+            },
           },
-        },
-      }),
-      requiredUint32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_uint32_value",
-            typeFullName: "uint32",
+        }),
+        requiredUint32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_uint32_value",
+              typeFullName: "uint32",
+            },
           },
-        },
-      }),
-      requiredUint64Value: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_uint64_value",
-            typeFullName: "uint64",
+        }),
+        requiredUint64Value: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_uint64_value",
+              typeFullName: "uint64",
+            },
           },
-        },
-      }),
-      requiredSint32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sint32_value",
-            typeFullName: "sint32",
+        }),
+        requiredSint32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sint32_value",
+              typeFullName: "sint32",
+            },
           },
-        },
-      }),
-      requiredSint64Value: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sint64_value",
-            typeFullName: "sint64",
+        }),
+        requiredSint64Value: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sint64_value",
+              typeFullName: "sint64",
+            },
           },
-        },
-      }),
-      requiredFixed32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_fixed32_value",
-            typeFullName: "fixed32",
+        }),
+        requiredFixed32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_fixed32_value",
+              typeFullName: "fixed32",
+            },
           },
-        },
-      }),
-      requiredFixed64Value: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_fixed64_value",
-            typeFullName: "fixed64",
+        }),
+        requiredFixed64Value: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_fixed64_value",
+              typeFullName: "fixed64",
+            },
           },
-        },
-      }),
-      requiredSfixed32Value: t.field({
-        type: "Int",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sfixed32_value",
-            typeFullName: "sfixed32",
+        }),
+        requiredSfixed32Value: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sfixed32_value",
+              typeFullName: "sfixed32",
+            },
           },
-        },
-      }),
-      requiredSfixed64Value: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_sfixed64_value",
-            typeFullName: "sfixed64",
+        }),
+        requiredSfixed64Value: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_sfixed64_value",
+              typeFullName: "sfixed64",
+            },
           },
-        },
-      }),
-      requiredBoolValue: t.field({
-        type: "Boolean",
-        required: true,
-        extensions: {
-          protobufField: { name: "required_bool_value", typeFullName: "bool" },
-        },
-      }),
-      requiredStringValue: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_string_value",
-            typeFullName: "string",
+        }),
+        requiredBoolValue: t.field({
+          type: "Boolean",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_bool_value",
+              typeFullName: "bool",
+            },
           },
-        },
-      }),
-      requiredBytesValue: t.field({
-        type: "Byte",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "required_bytes_value",
-            typeFullName: "bytes",
+        }),
+        requiredStringValue: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_string_value",
+              typeFullName: "string",
+            },
           },
-        },
-      }),
-      requiredDoubleValues: t.field({
-        type: ["Float"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_double_values",
-            typeFullName: "double",
+        }),
+        requiredBytesValue: t.field({
+          type: "Byte",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "required_bytes_value",
+              typeFullName: "bytes",
+            },
           },
-        },
-      }),
-      requiredFloatValues: t.field({
-        type: ["Float"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_float_values",
-            typeFullName: "float",
+        }),
+        requiredDoubleValues: t.field({
+          type: ["Float"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_double_values",
+              typeFullName: "double",
+            },
           },
-        },
-      }),
-      requiredInt32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_int32_values",
-            typeFullName: "int32",
+        }),
+        requiredFloatValues: t.field({
+          type: ["Float"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_float_values",
+              typeFullName: "float",
+            },
           },
-        },
-      }),
-      requiredInt64Values: t.field({
-        type: ["String"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_int64_values",
-            typeFullName: "int64",
+        }),
+        requiredInt32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_int32_values",
+              typeFullName: "int32",
+            },
           },
-        },
-      }),
-      requiredUint32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_uint32_values",
-            typeFullName: "uint32",
+        }),
+        requiredInt64Values: t.field({
+          type: ["String"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_int64_values",
+              typeFullName: "int64",
+            },
           },
-        },
-      }),
-      requiredUint64Values: t.field({
-        type: ["String"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_uint64_values",
-            typeFullName: "uint64",
+        }),
+        requiredUint32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_uint32_values",
+              typeFullName: "uint32",
+            },
           },
-        },
-      }),
-      requiredSint32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sint32_values",
-            typeFullName: "sint32",
+        }),
+        requiredUint64Values: t.field({
+          type: ["String"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_uint64_values",
+              typeFullName: "uint64",
+            },
           },
-        },
-      }),
-      requiredSint64Values: t.field({
-        type: ["String"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sint64_values",
-            typeFullName: "sint64",
+        }),
+        requiredSint32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sint32_values",
+              typeFullName: "sint32",
+            },
           },
-        },
-      }),
-      requiredFixed32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_fixed32_values",
-            typeFullName: "fixed32",
+        }),
+        requiredSint64Values: t.field({
+          type: ["String"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sint64_values",
+              typeFullName: "sint64",
+            },
           },
-        },
-      }),
-      requiredFixed64Values: t.field({
-        type: ["String"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_fixed64_values",
-            typeFullName: "fixed64",
+        }),
+        requiredFixed32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_fixed32_values",
+              typeFullName: "fixed32",
+            },
           },
-        },
-      }),
-      requiredSfixed32Values: t.field({
-        type: ["Int"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sfixed32_values",
-            typeFullName: "sfixed32",
+        }),
+        requiredFixed64Values: t.field({
+          type: ["String"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_fixed64_values",
+              typeFullName: "fixed64",
+            },
           },
-        },
-      }),
-      requiredSfixed64Values: t.field({
-        type: ["String"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_sfixed64_values",
-            typeFullName: "sfixed64",
+        }),
+        requiredSfixed32Values: t.field({
+          type: ["Int"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sfixed32_values",
+              typeFullName: "sfixed32",
+            },
           },
-        },
-      }),
-      requiredBoolValues: t.field({
-        type: ["Boolean"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: { name: "required_bool_values", typeFullName: "bool" },
-        },
-      }),
-      requiredStringValues: t.field({
-        type: ["String"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_string_values",
-            typeFullName: "string",
+        }),
+        requiredSfixed64Values: t.field({
+          type: ["String"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_sfixed64_values",
+              typeFullName: "sfixed64",
+            },
           },
-        },
-      }),
-      requiredBytesValues: t.field({
-        type: ["Byte"],
-        required: { list: true, items: true },
-        extensions: {
-          protobufField: {
-            name: "required_bytes_values",
-            typeFullName: "bytes",
+        }),
+        requiredBoolValues: t.field({
+          type: ["Boolean"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_bool_values",
+              typeFullName: "bool",
+            },
           },
-        },
+        }),
+        requiredStringValues: t.field({
+          type: ["String"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_string_values",
+              typeFullName: "string",
+            },
+          },
+        }),
+        requiredBytesValues: t.field({
+          type: ["Byte"],
+          required: { list: true, items: true },
+          extensions: {
+            protobufField: {
+              name: "required_bytes_values",
+              typeFullName: "bytes",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.basic.scalars.Primitives",
-        name: "Primitives",
-        package: "testapis.basic.scalars",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.basic.scalars.Primitives",
+          name: "Primitives",
+          package: "testapis.basic.scalars",
+        },
       },
-    },
-  });
+    });

--- a/tests/golden/ts-proto/testapis.basic.wktypes/__expected__/testapis/basic/wktypes/wktypes.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.basic.wktypes/__expected__/testapis/basic/wktypes/wktypes.pb.pothos.ts
@@ -131,8 +131,10 @@ builder.objectType(Message$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Message | { $type: string & {}; }).$type ===
-      "testapis.basic.wktypes.Message";
+    return (
+      (source as Message | { $type: string & {} }).$type ===
+      "testapis.basic.wktypes.Message"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -158,7 +160,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       timestamp: t.field({
         type: "DateTime",

--- a/tests/golden/ts-proto/testapis.behavior.field_comments/__expected__/testapis/behavior/field_comments/field_comments.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.behavior.field_comments/__expected__/testapis/behavior/field_comments/field_comments.pb.pothos.ts
@@ -9,9 +9,10 @@ import {
 } from "@proto-graphql/e2e-testapis-ts-proto/lib/testapis/behavior/field_comments/field_comments";
 import { InputObjectRef } from "@pothos/core";
 
-export const FieldBehaviorCommentsMessage$Ref = builder.objectRef<
-  FieldBehaviorCommentsMessage
->("FieldBehaviorCommentsMessage");
+export const FieldBehaviorCommentsMessage$Ref =
+  builder.objectRef<FieldBehaviorCommentsMessage>(
+    "FieldBehaviorCommentsMessage",
+  );
 builder.objectType(FieldBehaviorCommentsMessage$Ref, {
   name: "FieldBehaviorCommentsMessage",
   fields: (t) => ({
@@ -74,9 +75,11 @@ builder.objectType(FieldBehaviorCommentsMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as FieldBehaviorCommentsMessage | { $type: string & {}; })
-      .$type ===
-      "testapis.behavior.field_comments.FieldBehaviorCommentsMessage";
+    return (
+      (source as FieldBehaviorCommentsMessage | { $type: string & {} })
+        .$type ===
+      "testapis.behavior.field_comments.FieldBehaviorCommentsMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -87,9 +90,10 @@ builder.objectType(FieldBehaviorCommentsMessage$Ref, {
   },
 });
 
-export const FieldBehaviorCommentsMessagePost$Ref = builder.objectRef<
-  FieldBehaviorCommentsMessage_Post
->("FieldBehaviorCommentsMessagePost");
+export const FieldBehaviorCommentsMessagePost$Ref =
+  builder.objectRef<FieldBehaviorCommentsMessage_Post>(
+    "FieldBehaviorCommentsMessagePost",
+  );
 builder.objectType(FieldBehaviorCommentsMessagePost$Ref, {
   name: "FieldBehaviorCommentsMessagePost",
   fields: (t) => ({
@@ -100,10 +104,11 @@ builder.objectType(FieldBehaviorCommentsMessagePost$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as FieldBehaviorCommentsMessage_Post | {
-      $type: string & {};
-    }).$type ===
-      "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post";
+    return (
+      (source as FieldBehaviorCommentsMessage_Post | { $type: string & {} })
+        .$type ===
+      "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -122,92 +127,97 @@ export type FieldBehaviorCommentsMessageInput$Shape = {
   inputOnlyField?: FieldBehaviorCommentsMessagePostInput$Shape | null;
 };
 
-export const FieldBehaviorCommentsMessageInput$Ref: InputObjectRef<
-  FieldBehaviorCommentsMessageInput$Shape
-> = builder.inputRef<FieldBehaviorCommentsMessageInput$Shape>(
-  "FieldBehaviorCommentsMessageInput",
-).implement({
-  fields: (t) => ({
-    requiredField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: true,
-      description: "Required.",
+export const FieldBehaviorCommentsMessageInput$Ref: InputObjectRef<FieldBehaviorCommentsMessageInput$Shape> =
+  builder
+    .inputRef<FieldBehaviorCommentsMessageInput$Shape>(
+      "FieldBehaviorCommentsMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        requiredField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "required_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+        requiredInputOnlyField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: true,
+          description: "Required. Input only.",
+          extensions: {
+            protobufField: {
+              name: "required_input_only_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+        inputOnlyRequiredField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: true,
+          description: "Input only. Required.",
+          extensions: {
+            protobufField: {
+              name: "input_only_required_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+        inputOnlyField: t.field({
+          type: FieldBehaviorCommentsMessagePostInput$Ref,
+          required: false,
+          description: "Input only.",
+          extensions: {
+            protobufField: {
+              name: "input_only_field",
+              typeFullName:
+                "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "required_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+        protobufMessage: {
+          fullName:
+            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage",
+          name: "FieldBehaviorCommentsMessage",
+          package: "testapis.behavior.field_comments",
         },
       },
-    }),
-    requiredInputOnlyField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: true,
-      description: "Required. Input only.",
-      extensions: {
-        protobufField: {
-          name: "required_input_only_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-        },
-      },
-    }),
-    inputOnlyRequiredField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: true,
-      description: "Input only. Required.",
-      extensions: {
-        protobufField: {
-          name: "input_only_required_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-        },
-      },
-    }),
-    inputOnlyField: t.field({
-      type: FieldBehaviorCommentsMessagePostInput$Ref,
-      required: false,
-      description: "Input only.",
-      extensions: {
-        protobufField: {
-          name: "input_only_field",
-          typeFullName:
-            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.behavior.field_comments.FieldBehaviorCommentsMessage",
-      name: "FieldBehaviorCommentsMessage",
-      package: "testapis.behavior.field_comments",
-    },
-  },
-});
+    });
 
 export type FieldBehaviorCommentsMessagePostInput$Shape = {
   body: FieldBehaviorCommentsMessage_Post["body"];
 };
 
-export const FieldBehaviorCommentsMessagePostInput$Ref: InputObjectRef<
-  FieldBehaviorCommentsMessagePostInput$Shape
-> = builder.inputRef<FieldBehaviorCommentsMessagePostInput$Shape>(
-  "FieldBehaviorCommentsMessagePostInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
-      name: "Post",
-      package: "testapis.behavior.field_comments",
-    },
-  },
-});
+export const FieldBehaviorCommentsMessagePostInput$Ref: InputObjectRef<FieldBehaviorCommentsMessagePostInput$Shape> =
+  builder
+    .inputRef<FieldBehaviorCommentsMessagePostInput$Shape>(
+      "FieldBehaviorCommentsMessagePostInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.behavior.field_comments.FieldBehaviorCommentsMessage.Post",
+          name: "Post",
+          package: "testapis.behavior.field_comments",
+        },
+      },
+    });

--- a/tests/golden/ts-proto/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_a/types.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_a/types.pb.pothos.ts
@@ -23,8 +23,10 @@ builder.objectType(BaseMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as BaseMessage | { $type: string & {}; }).$type ===
-      "testapis.imports.cross_pkg_a.BaseMessage";
+    return (
+      (source as BaseMessage | { $type: string & {} }).$type ===
+      "testapis.imports.cross_pkg_a.BaseMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -47,8 +49,10 @@ builder.objectType(Parent$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Parent | { $type: string & {}; }).$type ===
-      "testapis.imports.cross_pkg_a.Parent";
+    return (
+      (source as Parent | { $type: string & {} }).$type ===
+      "testapis.imports.cross_pkg_a.Parent"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -70,8 +74,10 @@ builder.objectType(ParentChild$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Parent_Child | { $type: string & {}; }).$type ===
-      "testapis.imports.cross_pkg_a.Parent.Child";
+    return (
+      (source as Parent_Child | { $type: string & {} }).$type ===
+      "testapis.imports.cross_pkg_a.Parent.Child"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -82,30 +88,37 @@ builder.objectType(ParentChild$Ref, {
   },
 });
 
-export type BaseMessageInput$Shape = { body: BaseMessage["body"]; };
+export type BaseMessageInput$Shape = {
+  body: BaseMessage["body"];
+};
 
 export const BaseMessageInput$Ref: InputObjectRef<BaseMessageInput$Shape> =
-  builder.inputRef<BaseMessageInput$Shape>("BaseMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<BaseMessageInput$Shape>("BaseMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.cross_pkg_a.BaseMessage",
-        name: "BaseMessage",
-        package: "testapis.imports.cross_pkg_a",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.cross_pkg_a.BaseMessage",
+          name: "BaseMessage",
+          package: "testapis.imports.cross_pkg_a",
+        },
       },
-    },
-  });
+    });
 
 export type ParentInput$Shape = {};
 
 export const ParentInput$Ref: InputObjectRef<ParentInput$Shape> = builder
-  .inputRef<ParentInput$Shape>("ParentInput").implement({
+  .inputRef<ParentInput$Shape>("ParentInput")
+  .implement({
     fields: (t) => ({
       _: t.field({
         type: "Boolean",
@@ -122,25 +135,31 @@ export const ParentInput$Ref: InputObjectRef<ParentInput$Shape> = builder
     },
   });
 
-export type ParentChildInput$Shape = { body: Parent_Child["body"]; };
+export type ParentChildInput$Shape = {
+  body: Parent_Child["body"];
+};
 
 export const ParentChildInput$Ref: InputObjectRef<ParentChildInput$Shape> =
-  builder.inputRef<ParentChildInput$Shape>("ParentChildInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<ParentChildInput$Shape>("ParentChildInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.cross_pkg_a.Parent.Child",
-        name: "Child",
-        package: "testapis.imports.cross_pkg_a",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.cross_pkg_a.Parent.Child",
+          name: "Child",
+          package: "testapis.imports.cross_pkg_a",
+        },
       },
-    },
-  });
+    });
 
 export const BaseEnum$Ref: EnumRef<BaseEnum, BaseEnum> = builder.enumType(
   "BaseEnum",

--- a/tests/golden/ts-proto/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_b/consumer.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.cross_pkg_b/__expected__/testapis/imports/cross_pkg_b/consumer.pb.pothos.ts
@@ -80,8 +80,10 @@ builder.objectType(Consumer$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Consumer | { $type: string & {}; }).$type ===
-      "testapis.imports.cross_pkg_b.Consumer";
+    return (
+      (source as Consumer | { $type: string & {} }).$type ===
+      "testapis.imports.cross_pkg_b.Consumer"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -100,7 +102,8 @@ export type ConsumerInput$Shape = {
 };
 
 export const ConsumerInput$Ref: InputObjectRef<ConsumerInput$Shape> = builder
-  .inputRef<ConsumerInput$Shape>("ConsumerInput").implement({
+  .inputRef<ConsumerInput$Shape>("ConsumerInput")
+  .implement({
     fields: (t) => ({
       message: t.field({
         type: BaseMessageInput$Ref,

--- a/tests/golden/ts-proto/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/member.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/member.pb.pothos.ts
@@ -20,8 +20,10 @@ builder.objectType(OneofMember1$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as OneofMember1 | { $type: string & {}; }).$type ===
-      "testapis.imports.oneof_cross_file.OneofMember1";
+    return (
+      (source as OneofMember1 | { $type: string & {} }).$type ===
+      "testapis.imports.oneof_cross_file.OneofMember1"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -43,8 +45,10 @@ builder.objectType(OneofMember2$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as OneofMember2 | { $type: string & {}; }).$type ===
-      "testapis.imports.oneof_cross_file.OneofMember2";
+    return (
+      (source as OneofMember2 | { $type: string & {} }).$type ===
+      "testapis.imports.oneof_cross_file.OneofMember2"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -55,42 +59,54 @@ builder.objectType(OneofMember2$Ref, {
   },
 });
 
-export type OneofMember1Input$Shape = { body: OneofMember1["body"]; };
+export type OneofMember1Input$Shape = {
+  body: OneofMember1["body"];
+};
 
 export const OneofMember1Input$Ref: InputObjectRef<OneofMember1Input$Shape> =
-  builder.inputRef<OneofMember1Input$Shape>("OneofMember1Input").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<OneofMember1Input$Shape>("OneofMember1Input")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.oneof_cross_file.OneofMember1",
-        name: "OneofMember1",
-        package: "testapis.imports.oneof_cross_file",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.oneof_cross_file.OneofMember1",
+          name: "OneofMember1",
+          package: "testapis.imports.oneof_cross_file",
+        },
       },
-    },
-  });
+    });
 
-export type OneofMember2Input$Shape = { count: OneofMember2["count"]; };
+export type OneofMember2Input$Shape = {
+  count: OneofMember2["count"];
+};
 
 export const OneofMember2Input$Ref: InputObjectRef<OneofMember2Input$Shape> =
-  builder.inputRef<OneofMember2Input$Shape>("OneofMember2Input").implement({
-    fields: (t) => ({
-      count: t.field({
-        type: "Int",
-        required: true,
-        extensions: { protobufField: { name: "count", typeFullName: "int32" } },
+  builder
+    .inputRef<OneofMember2Input$Shape>("OneofMember2Input")
+    .implement({
+      fields: (t) => ({
+        count: t.field({
+          type: "Int",
+          required: true,
+          extensions: {
+            protobufField: { name: "count", typeFullName: "int32" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.oneof_cross_file.OneofMember2",
-        name: "OneofMember2",
-        package: "testapis.imports.oneof_cross_file",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.oneof_cross_file.OneofMember2",
+          name: "OneofMember2",
+          package: "testapis.imports.oneof_cross_file",
+        },
       },
-    },
-  });
+    });

--- a/tests/golden/ts-proto/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/parent.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.oneof_cross_file/__expected__/testapis/imports/oneof_cross_file/parent.pb.pothos.ts
@@ -32,8 +32,10 @@ builder.objectType(OneofParent$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as OneofParent | { $type: string & {}; }).$type ===
-      "testapis.imports.oneof_cross_file.OneofParent";
+    return (
+      (source as OneofParent | { $type: string & {} }).$type ===
+      "testapis.imports.oneof_cross_file.OneofParent"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -50,37 +52,39 @@ export type OneofParentInput$Shape = {
 };
 
 export const OneofParentInput$Ref: InputObjectRef<OneofParentInput$Shape> =
-  builder.inputRef<OneofParentInput$Shape>("OneofParentInput").implement({
-    fields: (t) => ({
-      member1: t.field({
-        type: OneofMember1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "member1",
-            typeFullName: "testapis.imports.oneof_cross_file.OneofMember1",
+  builder
+    .inputRef<OneofParentInput$Shape>("OneofParentInput")
+    .implement({
+      fields: (t) => ({
+        member1: t.field({
+          type: OneofMember1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "member1",
+              typeFullName: "testapis.imports.oneof_cross_file.OneofMember1",
+            },
           },
-        },
-      }),
-      member2: t.field({
-        type: OneofMember2Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "member2",
-            typeFullName: "testapis.imports.oneof_cross_file.OneofMember2",
+        }),
+        member2: t.field({
+          type: OneofMember2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "member2",
+              typeFullName: "testapis.imports.oneof_cross_file.OneofMember2",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.oneof_cross_file.OneofParent",
-        name: "OneofParent",
-        package: "testapis.imports.oneof_cross_file",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.oneof_cross_file.OneofParent",
+          name: "OneofParent",
+          package: "testapis.imports.oneof_cross_file",
+        },
       },
-    },
-  });
+    });
 
 export const OneofParentOneofField$Ref = builder.unionType(
   "OneofParentOneofField",
@@ -92,13 +96,16 @@ export const OneofParentOneofField$Ref = builder.unionType(
         name: "oneof_field",
         messageName: "OneofParent",
         package: "testapis.imports.oneof_cross_file",
-        fields: [{
-          name: "member1",
-          type: "testapis.imports.oneof_cross_file.OneofMember1",
-        }, {
-          name: "member2",
-          type: "testapis.imports.oneof_cross_file.OneofMember2",
-        }],
+        fields: [
+          {
+            name: "member1",
+            type: "testapis.imports.oneof_cross_file.OneofMember1",
+          },
+          {
+            name: "member2",
+            type: "testapis.imports.oneof_cross_file.OneofMember2",
+          },
+        ],
       },
     },
   },

--- a/tests/golden/ts-proto/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/base.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/base.pb.pothos.ts
@@ -9,9 +9,8 @@ import {
 } from "@proto-graphql/e2e-testapis-ts-proto/lib/testapis/imports/same_dir/base";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const SharedMessage$Ref = builder.objectRef<SharedMessage>(
-  "SharedMessage",
-);
+export const SharedMessage$Ref =
+  builder.objectRef<SharedMessage>("SharedMessage");
 builder.objectType(SharedMessage$Ref, {
   name: "SharedMessage",
   fields: (t) => ({
@@ -22,8 +21,10 @@ builder.objectType(SharedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as SharedMessage | { $type: string & {}; }).$type ===
-      "testapis.imports.same_dir.SharedMessage";
+    return (
+      (source as SharedMessage | { $type: string & {} }).$type ===
+      "testapis.imports.same_dir.SharedMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -34,25 +35,31 @@ builder.objectType(SharedMessage$Ref, {
   },
 });
 
-export type SharedMessageInput$Shape = { body: SharedMessage["body"]; };
+export type SharedMessageInput$Shape = {
+  body: SharedMessage["body"];
+};
 
 export const SharedMessageInput$Ref: InputObjectRef<SharedMessageInput$Shape> =
-  builder.inputRef<SharedMessageInput$Shape>("SharedMessageInput").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<SharedMessageInput$Shape>("SharedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.same_dir.SharedMessage",
-        name: "SharedMessage",
-        package: "testapis.imports.same_dir",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.same_dir.SharedMessage",
+          name: "SharedMessage",
+          package: "testapis.imports.same_dir",
+        },
       },
-    },
-  });
+    });
 
 export const SharedEnum$Ref: EnumRef<SharedEnum, SharedEnum> = builder.enumType(
   "SharedEnum",

--- a/tests/golden/ts-proto/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/consumer.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.same_dir/__expected__/testapis/imports/same_dir/consumer.pb.pothos.ts
@@ -46,8 +46,10 @@ builder.objectType(Consumer$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Consumer | { $type: string & {}; }).$type ===
-      "testapis.imports.same_dir.Consumer";
+    return (
+      (source as Consumer | { $type: string & {} }).$type ===
+      "testapis.imports.same_dir.Consumer"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -64,7 +66,8 @@ export type ConsumerInput$Shape = {
 };
 
 export const ConsumerInput$Ref: InputObjectRef<ConsumerInput$Shape> = builder
-  .inputRef<ConsumerInput$Shape>("ConsumerInput").implement({
+  .inputRef<ConsumerInput$Shape>("ConsumerInput")
+  .implement({
     fields: (t) => ({
       message: t.field({
         type: SharedMessageInput$Ref,

--- a/tests/golden/ts-proto/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg1.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg1.pb.pothos.ts
@@ -6,9 +6,8 @@ import { builder } from "../../../../builder";
 import { OneofMessage1 } from "@proto-graphql/e2e-testapis-ts-proto/lib/testapis/imports/squashed_union/pkg1";
 import { InputObjectRef } from "@pothos/core";
 
-export const OneofMessage1$Ref = builder.objectRef<OneofMessage1>(
-  "OneofMessage1",
-);
+export const OneofMessage1$Ref =
+  builder.objectRef<OneofMessage1>("OneofMessage1");
 builder.objectType(OneofMessage1$Ref, {
   name: "OneofMessage1",
   fields: (t) => ({
@@ -19,8 +18,10 @@ builder.objectType(OneofMessage1$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as OneofMessage1 | { $type: string & {}; }).$type ===
-      "testapis.imports.squashed_union.pkg1.OneofMessage1";
+    return (
+      (source as OneofMessage1 | { $type: string & {} }).$type ===
+      "testapis.imports.squashed_union.pkg1.OneofMessage1"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -31,53 +32,62 @@ builder.objectType(OneofMessage1$Ref, {
   },
 });
 
-export type OneofMessage1Input$Shape = { body: OneofMessage1["body"]; };
+export type OneofMessage1Input$Shape = {
+  body: OneofMessage1["body"];
+};
 
 export const OneofMessage1Input$Ref: InputObjectRef<OneofMessage1Input$Shape> =
-  builder.inputRef<OneofMessage1Input$Shape>("OneofMessage1Input").implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+  builder
+    .inputRef<OneofMessage1Input$Shape>("OneofMessage1Input")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.squashed_union.pkg1.OneofMessage1",
-        name: "OneofMessage1",
-        package: "testapis.imports.squashed_union.pkg1",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.squashed_union.pkg1.OneofMessage1",
+          name: "OneofMessage1",
+          package: "testapis.imports.squashed_union.pkg1",
+        },
       },
-    },
-  });
+    });
 
 export type SquashedOneofInput$Shape = {
   msg1?: OneofMessage1Input$Shape | null;
 };
 
 export const SquashedOneofInput$Ref: InputObjectRef<SquashedOneofInput$Shape> =
-  builder.inputRef<SquashedOneofInput$Shape>("SquashedOneofInput").implement({
-    fields: (t) => ({
-      msg1: t.field({
-        type: OneofMessage1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "msg1",
-            typeFullName: "testapis.imports.squashed_union.pkg1.OneofMessage1",
+  builder
+    .inputRef<SquashedOneofInput$Shape>("SquashedOneofInput")
+    .implement({
+      fields: (t) => ({
+        msg1: t.field({
+          type: OneofMessage1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "msg1",
+              typeFullName:
+                "testapis.imports.squashed_union.pkg1.OneofMessage1",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.imports.squashed_union.pkg1.SquashedOneof",
-        name: "SquashedOneof",
-        package: "testapis.imports.squashed_union.pkg1",
-        options: { "[graphql.object_type]": { squashUnion: true } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.imports.squashed_union.pkg1.SquashedOneof",
+          name: "SquashedOneof",
+          package: "testapis.imports.squashed_union.pkg1",
+          options: { "[graphql.object_type]": { squashUnion: true } },
+        },
       },
-    },
-  });
+    });
 
 export const SquashedOneof$Ref = builder.unionType("SquashedOneof", {
   types: [OneofMessage1$Ref],
@@ -86,11 +96,13 @@ export const SquashedOneof$Ref = builder.unionType("SquashedOneof", {
       fullName: "testapis.imports.squashed_union.pkg1.SquashedOneof",
       name: "SquashedOneof",
       package: "testapis.imports.squashed_union.pkg1",
-      fields: [{
-        name: "msg1",
-        type: "testapis.imports.squashed_union.pkg1.OneofMessage1",
-        options: { "[graphql.object_type]": { squashUnion: true } },
-      }],
+      fields: [
+        {
+          name: "msg1",
+          type: "testapis.imports.squashed_union.pkg1.OneofMessage1",
+          options: { "[graphql.object_type]": { squashUnion: true } },
+        },
+      ],
     },
   },
 });

--- a/tests/golden/ts-proto/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg2.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.squashed_union/__expected__/testapis/imports/squashed_union/pkg2.pb.pothos.ts
@@ -34,8 +34,10 @@ builder.objectType(Message$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Message | { $type: string & {}; }).$type ===
-      "testapis.imports.squashed_union.pkg2.Message";
+    return (
+      (source as Message | { $type: string & {} }).$type ===
+      "testapis.imports.squashed_union.pkg2.Message"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -46,10 +48,13 @@ builder.objectType(Message$Ref, {
   },
 });
 
-export type MessageInput$Shape = { msg?: SquashedOneofInput$Shape | null; };
+export type MessageInput$Shape = {
+  msg?: SquashedOneofInput$Shape | null;
+};
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       msg: t.field({
         type: SquashedOneofInput$Ref,

--- a/tests/golden/ts-proto/testapis.imports.transitive/__expected__/testapis/imports/transitive/a.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.transitive/__expected__/testapis/imports/transitive/a.pb.pothos.ts
@@ -23,8 +23,10 @@ builder.objectType(A$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as A | { $type: string & {}; }).$type ===
-      "testapis.imports.transitive.A";
+    return (
+      (source as A | { $type: string & {} }).$type ===
+      "testapis.imports.transitive.A"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -35,28 +37,30 @@ builder.objectType(A$Ref, {
   },
 });
 
-export type AInput$Shape = { b?: BInput$Shape | null; };
+export type AInput$Shape = {
+  b?: BInput$Shape | null;
+};
 
-export const AInput$Ref: InputObjectRef<AInput$Shape> = builder.inputRef<
-  AInput$Shape
->("AInput").implement({
-  fields: (t) => ({
-    b: t.field({
-      type: BInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "b",
-          typeFullName: "testapis.imports.transitive.B",
+export const AInput$Ref: InputObjectRef<AInput$Shape> = builder
+  .inputRef<AInput$Shape>("AInput")
+  .implement({
+    fields: (t) => ({
+      b: t.field({
+        type: BInput$Ref,
+        required: false,
+        extensions: {
+          protobufField: {
+            name: "b",
+            typeFullName: "testapis.imports.transitive.B",
+          },
         },
-      },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.imports.transitive.A",
-      name: "A",
-      package: "testapis.imports.transitive",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.imports.transitive.A",
+        name: "A",
+        package: "testapis.imports.transitive",
+      },
     },
-  },
-});
+  });

--- a/tests/golden/ts-proto/testapis.imports.transitive/__expected__/testapis/imports/transitive/b.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.transitive/__expected__/testapis/imports/transitive/b.pb.pothos.ts
@@ -23,8 +23,10 @@ builder.objectType(B$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as B | { $type: string & {}; }).$type ===
-      "testapis.imports.transitive.B";
+    return (
+      (source as B | { $type: string & {} }).$type ===
+      "testapis.imports.transitive.B"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -35,28 +37,30 @@ builder.objectType(B$Ref, {
   },
 });
 
-export type BInput$Shape = { c?: CInput$Shape | null; };
+export type BInput$Shape = {
+  c?: CInput$Shape | null;
+};
 
-export const BInput$Ref: InputObjectRef<BInput$Shape> = builder.inputRef<
-  BInput$Shape
->("BInput").implement({
-  fields: (t) => ({
-    c: t.field({
-      type: CInput$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "c",
-          typeFullName: "testapis.imports.transitive.C",
+export const BInput$Ref: InputObjectRef<BInput$Shape> = builder
+  .inputRef<BInput$Shape>("BInput")
+  .implement({
+    fields: (t) => ({
+      c: t.field({
+        type: CInput$Ref,
+        required: false,
+        extensions: {
+          protobufField: {
+            name: "c",
+            typeFullName: "testapis.imports.transitive.C",
+          },
         },
-      },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.imports.transitive.B",
-      name: "B",
-      package: "testapis.imports.transitive",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.imports.transitive.B",
+        name: "B",
+        package: "testapis.imports.transitive",
+      },
     },
-  },
-});
+  });

--- a/tests/golden/ts-proto/testapis.imports.transitive/__expected__/testapis/imports/transitive/c.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.imports.transitive/__expected__/testapis/imports/transitive/c.pb.pothos.ts
@@ -17,8 +17,10 @@ builder.objectType(C$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as C | { $type: string & {}; }).$type ===
-      "testapis.imports.transitive.C";
+    return (
+      (source as C | { $type: string & {} }).$type ===
+      "testapis.imports.transitive.C"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -29,23 +31,25 @@ builder.objectType(C$Ref, {
   },
 });
 
-export type CInput$Shape = { body: C["body"]; };
+export type CInput$Shape = {
+  body: C["body"];
+};
 
-export const CInput$Ref: InputObjectRef<CInput$Shape> = builder.inputRef<
-  CInput$Shape
->("CInput").implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const CInput$Ref: InputObjectRef<CInput$Shape> = builder
+  .inputRef<CInput$Shape>("CInput")
+  .implement({
+    fields: (t) => ({
+      body: t.field({
+        type: "String",
+        required: true,
+        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+      }),
     }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.imports.transitive.C",
-      name: "C",
-      package: "testapis.imports.transitive",
+    extensions: {
+      protobufMessage: {
+        fullName: "testapis.imports.transitive.C",
+        name: "C",
+        package: "testapis.imports.transitive",
+      },
     },
-  },
-});
+  });

--- a/tests/golden/ts-proto/testapis.oneof.message_only/__expected__/testapis/oneof/message_only/message_only.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.oneof.message_only/__expected__/testapis/oneof/message_only/message_only.pb.pothos.ts
@@ -48,8 +48,10 @@ builder.objectType(OneofParent$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as OneofParent | { $type: string & {}; }).$type ===
-      "testapis.oneof.message_only.OneofParent";
+    return (
+      (source as OneofParent | { $type: string & {} }).$type ===
+      "testapis.oneof.message_only.OneofParent"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -73,8 +75,10 @@ builder.objectType(OneofMemberMessage1$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as OneofMemberMessage1 | { $type: string & {}; }).$type ===
-      "testapis.oneof.message_only.OneofMemberMessage1";
+    return (
+      (source as OneofMemberMessage1 | { $type: string & {} }).$type ===
+      "testapis.oneof.message_only.OneofMemberMessage1"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -100,8 +104,10 @@ builder.objectType(OneofMemberMessage2$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as OneofMemberMessage2 | { $type: string & {}; }).$type ===
-      "testapis.oneof.message_only.OneofMemberMessage2";
+    return (
+      (source as OneofMemberMessage2 | { $type: string & {} }).$type ===
+      "testapis.oneof.message_only.OneofMemberMessage2"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -121,114 +127,118 @@ export type OneofParentInput$Shape = {
 };
 
 export const OneofParentInput$Ref: InputObjectRef<OneofParentInput$Shape> =
-  builder.inputRef<OneofParentInput$Shape>("OneofParentInput").implement({
-    fields: (t) => ({
-      normalField: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: { name: "normal_field", typeFullName: "string" },
-        },
-      }),
-      requiredMessage1: t.field({
-        type: OneofMemberMessage1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "required_message1",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+  builder
+    .inputRef<OneofParentInput$Shape>("OneofParentInput")
+    .implement({
+      fields: (t) => ({
+        normalField: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "normal_field", typeFullName: "string" },
           },
-        },
-      }),
-      requiredMessage2: t.field({
-        type: OneofMemberMessage2Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "required_message2",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+        }),
+        requiredMessage1: t.field({
+          type: OneofMemberMessage1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "required_message1",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+            },
           },
-        },
-      }),
-      optionalMessage1: t.field({
-        type: OneofMemberMessage1Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "optional_message1",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+        }),
+        requiredMessage2: t.field({
+          type: OneofMemberMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "required_message2",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+            },
           },
-        },
-      }),
-      optionalMessage2: t.field({
-        type: OneofMemberMessage2Input$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "optional_message2",
-            typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+        }),
+        optionalMessage1: t.field({
+          type: OneofMemberMessage1Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "optional_message1",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage1",
+            },
           },
-        },
+        }),
+        optionalMessage2: t.field({
+          type: OneofMemberMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "optional_message2",
+              typeFullName: "testapis.oneof.message_only.OneofMemberMessage2",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.message_only.OneofParent",
-        name: "OneofParent",
-        package: "testapis.oneof.message_only",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.message_only.OneofParent",
+          name: "OneofParent",
+          package: "testapis.oneof.message_only",
+        },
       },
-    },
-  });
+    });
 
 export type OneofMemberMessage1Input$Shape = {
   body: OneofMemberMessage1["body"];
 };
 
-export const OneofMemberMessage1Input$Ref: InputObjectRef<
-  OneofMemberMessage1Input$Shape
-> = builder.inputRef<OneofMemberMessage1Input$Shape>("OneofMemberMessage1Input")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const OneofMemberMessage1Input$Ref: InputObjectRef<OneofMemberMessage1Input$Shape> =
+  builder
+    .inputRef<OneofMemberMessage1Input$Shape>("OneofMemberMessage1Input")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.message_only.OneofMemberMessage1",
-        name: "OneofMemberMessage1",
-        package: "testapis.oneof.message_only",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.message_only.OneofMemberMessage1",
+          name: "OneofMemberMessage1",
+          package: "testapis.oneof.message_only",
+        },
       },
-    },
-  });
+    });
 
 export type OneofMemberMessage2Input$Shape = {
   imageUrl: OneofMemberMessage2["imageUrl"];
 };
 
-export const OneofMemberMessage2Input$Ref: InputObjectRef<
-  OneofMemberMessage2Input$Shape
-> = builder.inputRef<OneofMemberMessage2Input$Shape>("OneofMemberMessage2Input")
-  .implement({
-    fields: (t) => ({
-      imageUrl: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: { name: "image_url", typeFullName: "string" },
-        },
+export const OneofMemberMessage2Input$Ref: InputObjectRef<OneofMemberMessage2Input$Shape> =
+  builder
+    .inputRef<OneofMemberMessage2Input$Shape>("OneofMemberMessage2Input")
+    .implement({
+      fields: (t) => ({
+        imageUrl: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "image_url", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.oneof.message_only.OneofMemberMessage2",
-        name: "OneofMemberMessage2",
-        package: "testapis.oneof.message_only",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.oneof.message_only.OneofMemberMessage2",
+          name: "OneofMemberMessage2",
+          package: "testapis.oneof.message_only",
+        },
       },
-    },
-  });
+    });
 
 export const OneofParentRequiredOneofMembers$Ref = builder.unionType(
   "OneofParentRequiredOneofMembers",
@@ -242,13 +252,16 @@ export const OneofParentRequiredOneofMembers$Ref = builder.unionType(
         name: "required_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "required_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "required_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "required_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "required_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },
@@ -265,13 +278,16 @@ export const OneofParentOptionalOneofMembers$Ref = builder.unionType(
         name: "optional_oneof_members",
         messageName: "OneofParent",
         package: "testapis.oneof.message_only",
-        fields: [{
-          name: "optional_message1",
-          type: "testapis.oneof.message_only.OneofMemberMessage1",
-        }, {
-          name: "optional_message2",
-          type: "testapis.oneof.message_only.OneofMemberMessage2",
-        }],
+        fields: [
+          {
+            name: "optional_message1",
+            type: "testapis.oneof.message_only.OneofMemberMessage1",
+          },
+          {
+            name: "optional_message2",
+            type: "testapis.oneof.message_only.OneofMemberMessage2",
+          },
+        ],
       },
     },
   },

--- a/tests/golden/ts-proto/testapis.options.deprecation/__expected__/testapis/options/deprecation/deprecation.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.options.deprecation/__expected__/testapis/options/deprecation/deprecation.pb.pothos.ts
@@ -14,9 +14,8 @@ import {
 } from "@proto-graphql/e2e-testapis-ts-proto/lib/testapis/options/deprecation/deprecation";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const DeprecatedMessage$Ref = builder.objectRef<DeprecatedMessage>(
-  "DeprecatedMessage",
-);
+export const DeprecatedMessage$Ref =
+  builder.objectRef<DeprecatedMessage>("DeprecatedMessage");
 builder.objectType(DeprecatedMessage$Ref, {
   name: "DeprecatedMessage",
   fields: (t) => ({
@@ -48,8 +47,10 @@ builder.objectType(DeprecatedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as DeprecatedMessage | { $type: string & {}; }).$type ===
-      "testapis.options.deprecation.DeprecatedMessage";
+    return (
+      (source as DeprecatedMessage | { $type: string & {} }).$type ===
+      "testapis.options.deprecation.DeprecatedMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -129,8 +130,10 @@ builder.objectType(NotDeprecatedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as NotDeprecatedMessage | { $type: string & {}; }).$type ===
-      "testapis.options.deprecation.NotDeprecatedMessage";
+    return (
+      (source as NotDeprecatedMessage | { $type: string & {} }).$type ===
+      "testapis.options.deprecation.NotDeprecatedMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -141,9 +144,10 @@ builder.objectType(NotDeprecatedMessage$Ref, {
   },
 });
 
-export const DeprecatedMessageInnerMessage$Ref = builder.objectRef<
-  DeprecatedMessage_InnerMessage
->("DeprecatedMessageInnerMessage");
+export const DeprecatedMessageInnerMessage$Ref =
+  builder.objectRef<DeprecatedMessage_InnerMessage>(
+    "DeprecatedMessageInnerMessage",
+  );
 builder.objectType(DeprecatedMessageInnerMessage$Ref, {
   name: "DeprecatedMessageInnerMessage",
   fields: (t) => ({
@@ -156,8 +160,10 @@ builder.objectType(DeprecatedMessageInnerMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as DeprecatedMessage_InnerMessage | { $type: string & {}; })
-      .$type === "testapis.options.deprecation.DeprecatedMessage.InnerMessage";
+    return (
+      (source as DeprecatedMessage_InnerMessage | { $type: string & {} })
+        .$type === "testapis.options.deprecation.DeprecatedMessage.InnerMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -168,9 +174,10 @@ builder.objectType(DeprecatedMessageInnerMessage$Ref, {
   },
 });
 
-export const NotDeprecatedMessageInnerMessage1$Ref = builder.objectRef<
-  NotDeprecatedMessage_InnerMessage1
->("NotDeprecatedMessageInnerMessage1");
+export const NotDeprecatedMessageInnerMessage1$Ref =
+  builder.objectRef<NotDeprecatedMessage_InnerMessage1>(
+    "NotDeprecatedMessageInnerMessage1",
+  );
 builder.objectType(NotDeprecatedMessageInnerMessage1$Ref, {
   name: "NotDeprecatedMessageInnerMessage1",
   fields: (t) => ({
@@ -183,10 +190,11 @@ builder.objectType(NotDeprecatedMessageInnerMessage1$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as NotDeprecatedMessage_InnerMessage1 | {
-      $type: string & {};
-    }).$type ===
-      "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1";
+    return (
+      (source as NotDeprecatedMessage_InnerMessage1 | { $type: string & {} })
+        .$type ===
+      "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -198,9 +206,10 @@ builder.objectType(NotDeprecatedMessageInnerMessage1$Ref, {
   },
 });
 
-export const NotDeprecatedMessageInnerMessage2$Ref = builder.objectRef<
-  NotDeprecatedMessage_InnerMessage2
->("NotDeprecatedMessageInnerMessage2");
+export const NotDeprecatedMessageInnerMessage2$Ref =
+  builder.objectRef<NotDeprecatedMessage_InnerMessage2>(
+    "NotDeprecatedMessageInnerMessage2",
+  );
 builder.objectType(NotDeprecatedMessageInnerMessage2$Ref, {
   name: "NotDeprecatedMessageInnerMessage2",
   fields: (t) => ({
@@ -213,10 +222,11 @@ builder.objectType(NotDeprecatedMessageInnerMessage2$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as NotDeprecatedMessage_InnerMessage2 | {
-      $type: string & {};
-    }).$type ===
-      "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2";
+    return (
+      (source as NotDeprecatedMessage_InnerMessage2 | { $type: string & {} })
+        .$type ===
+      "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -233,40 +243,42 @@ export type DeprecatedMessageInput$Shape = {
   enum?: DeprecatedMessage["enum"] | null;
 };
 
-export const DeprecatedMessageInput$Ref: InputObjectRef<
-  DeprecatedMessageInput$Shape
-> = builder.inputRef<DeprecatedMessageInput$Shape>("DeprecatedMessageInput")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: false,
-        deprecationReason:
-          "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      enum: t.field({
-        type: NotDeprecatedEnum$Ref,
-        required: false,
-        deprecationReason:
-          "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-        extensions: {
-          protobufField: {
-            name: "enum",
-            typeFullName: "testapis.options.deprecation.NotDeprecatedEnum",
+export const DeprecatedMessageInput$Ref: InputObjectRef<DeprecatedMessageInput$Shape> =
+  builder
+    .inputRef<DeprecatedMessageInput$Shape>("DeprecatedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
+        }),
+        enum: t.field({
+          type: NotDeprecatedEnum$Ref,
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: {
+              name: "enum",
+              typeFullName: "testapis.options.deprecation.NotDeprecatedEnum",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.deprecation.DeprecatedMessage",
-        name: "DeprecatedMessage",
-        package: "testapis.options.deprecation",
-        options: { deprecated: true },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.deprecation.DeprecatedMessage",
+          name: "DeprecatedMessage",
+          package: "testapis.options.deprecation",
+          options: { deprecated: true },
+        },
       },
-    },
-  });
+    });
 
 export type NotDeprecatedMessageInput$Shape = {
   body?: NotDeprecatedMessage["body"] | null;
@@ -277,183 +289,192 @@ export type NotDeprecatedMessageInput$Shape = {
   msg4?: NotDeprecatedMessageInnerMessage2Input$Shape | null;
 };
 
-export const NotDeprecatedMessageInput$Ref: InputObjectRef<
-  NotDeprecatedMessageInput$Shape
-> = builder.inputRef<NotDeprecatedMessageInput$Shape>(
-  "NotDeprecatedMessageInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.NotDeprecatedMessage.body is mark as deprecated in a *.proto file.",
+export const NotDeprecatedMessageInput$Ref: InputObjectRef<NotDeprecatedMessageInput$Shape> =
+  builder
+    .inputRef<NotDeprecatedMessageInput$Shape>("NotDeprecatedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.NotDeprecatedMessage.body is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "body",
+              typeFullName: "string",
+              options: { deprecated: true },
+            },
+          },
+        }),
+        enum: t.field({
+          type: DeprecatedEnum$Ref,
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "enum",
+              typeFullName: "testapis.options.deprecation.DeprecatedEnum",
+            },
+          },
+        }),
+        msg1: t.field({
+          type: NotDeprecatedMessageInnerMessage1Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: {
+              name: "msg1",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+            },
+          },
+        }),
+        msg2: t.field({
+          type: NotDeprecatedMessageInnerMessage2Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: {
+              name: "msg2",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+            },
+          },
+        }),
+        msg3: t.field({
+          type: NotDeprecatedMessageInnerMessage1Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.NotDeprecatedMessage.msg3 is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "msg3",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+              options: { deprecated: true },
+            },
+          },
+        }),
+        msg4: t.field({
+          type: NotDeprecatedMessageInnerMessage2Input$Ref,
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.NotDeprecatedMessage.msg4 is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: {
+              name: "msg4",
+              typeFullName:
+                "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+              options: { deprecated: true },
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "body",
-          typeFullName: "string",
-          options: { deprecated: true },
+        protobufMessage: {
+          fullName: "testapis.options.deprecation.NotDeprecatedMessage",
+          name: "NotDeprecatedMessage",
+          package: "testapis.options.deprecation",
         },
       },
-    }),
-    enum: t.field({
-      type: DeprecatedEnum$Ref,
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.",
-      extensions: {
-        protobufField: {
-          name: "enum",
-          typeFullName: "testapis.options.deprecation.DeprecatedEnum",
-        },
-      },
-    }),
-    msg1: t.field({
-      type: NotDeprecatedMessageInnerMessage1Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: {
-        protobufField: {
-          name: "msg1",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-        },
-      },
-    }),
-    msg2: t.field({
-      type: NotDeprecatedMessageInnerMessage2Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: {
-        protobufField: {
-          name: "msg2",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-        },
-      },
-    }),
-    msg3: t.field({
-      type: NotDeprecatedMessageInnerMessage1Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.NotDeprecatedMessage.msg3 is mark as deprecated in a *.proto file.",
-      extensions: {
-        protobufField: {
-          name: "msg3",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-          options: { deprecated: true },
-        },
-      },
-    }),
-    msg4: t.field({
-      type: NotDeprecatedMessageInnerMessage2Input$Ref,
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.NotDeprecatedMessage.msg4 is mark as deprecated in a *.proto file.",
-      extensions: {
-        protobufField: {
-          name: "msg4",
-          typeFullName:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-          options: { deprecated: true },
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.deprecation.NotDeprecatedMessage",
-      name: "NotDeprecatedMessage",
-      package: "testapis.options.deprecation",
-    },
-  },
-});
+    });
 
 export type DeprecatedMessageInnerMessageInput$Shape = {
   body?: DeprecatedMessage_InnerMessage["body"] | null;
 };
 
-export const DeprecatedMessageInnerMessageInput$Ref: InputObjectRef<
-  DeprecatedMessageInnerMessageInput$Shape
-> = builder.inputRef<DeprecatedMessageInnerMessageInput$Shape>(
-  "DeprecatedMessageInnerMessageInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.deprecation.DeprecatedMessage.InnerMessage",
-      name: "InnerMessage",
-      package: "testapis.options.deprecation",
-    },
-  },
-});
+export const DeprecatedMessageInnerMessageInput$Ref: InputObjectRef<DeprecatedMessageInnerMessageInput$Shape> =
+  builder
+    .inputRef<DeprecatedMessageInnerMessageInput$Shape>(
+      "DeprecatedMessageInnerMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis.options.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.deprecation.DeprecatedMessage.InnerMessage",
+          name: "InnerMessage",
+          package: "testapis.options.deprecation",
+        },
+      },
+    });
 
 export type NotDeprecatedMessageInnerMessage1Input$Shape = {
   body?: NotDeprecatedMessage_InnerMessage1["body"] | null;
 };
 
-export const NotDeprecatedMessageInnerMessage1Input$Ref: InputObjectRef<
-  NotDeprecatedMessageInnerMessage1Input$Shape
-> = builder.inputRef<NotDeprecatedMessageInnerMessage1Input$Shape>(
-  "NotDeprecatedMessageInnerMessage1Input",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-      name: "InnerMessage1",
-      package: "testapis.options.deprecation",
-    },
-  },
-});
+export const NotDeprecatedMessageInnerMessage1Input$Ref: InputObjectRef<NotDeprecatedMessageInnerMessage1Input$Shape> =
+  builder
+    .inputRef<NotDeprecatedMessageInnerMessage1Input$Shape>(
+      "NotDeprecatedMessageInnerMessage1Input",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+          name: "InnerMessage1",
+          package: "testapis.options.deprecation",
+        },
+      },
+    });
 
 export type NotDeprecatedMessageInnerMessage2Input$Shape = {
   body?: NotDeprecatedMessage_InnerMessage2["body"] | null;
 };
 
-export const NotDeprecatedMessageInnerMessage2Input$Ref: InputObjectRef<
-  NotDeprecatedMessageInnerMessage2Input$Shape
-> = builder.inputRef<NotDeprecatedMessageInnerMessage2Input$Shape>(
-  "NotDeprecatedMessageInnerMessage2Input",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: false,
-      deprecationReason:
-        "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-      name: "InnerMessage2",
-      package: "testapis.options.deprecation",
-    },
-  },
-});
+export const NotDeprecatedMessageInnerMessage2Input$Ref: InputObjectRef<NotDeprecatedMessageInnerMessage2Input$Shape> =
+  builder
+    .inputRef<NotDeprecatedMessageInnerMessage2Input$Shape>(
+      "NotDeprecatedMessageInnerMessage2Input",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: false,
+          deprecationReason:
+            "testapis/options/deprecation/deprecation.proto is mark as deprecated.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+          name: "InnerMessage2",
+          package: "testapis.options.deprecation",
+        },
+      },
+    });
 
 export const NotDeprecatedMessageNotDeprecatedOneof$Ref = builder.unionType(
   "NotDeprecatedMessageNotDeprecatedOneof",
@@ -469,15 +490,16 @@ export const NotDeprecatedMessageNotDeprecatedOneof$Ref = builder.unionType(
         name: "not_deprecated_oneof",
         messageName: "NotDeprecatedMessage",
         package: "testapis.options.deprecation",
-        fields: [{
-          name: "msg1",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-        }, {
-          name: "msg2",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-        }],
+        fields: [
+          {
+            name: "msg1",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+          },
+          {
+            name: "msg2",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+          },
+        ],
       },
     },
   },
@@ -497,15 +519,16 @@ export const NotDeprecatedMessageDeprecatedOneof$Ref = builder.unionType(
         name: "deprecated_oneof",
         messageName: "NotDeprecatedMessage",
         package: "testapis.options.deprecation",
-        fields: [{
-          name: "msg3",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
-        }, {
-          name: "msg4",
-          type:
-            "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
-        }],
+        fields: [
+          {
+            name: "msg3",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage1",
+          },
+          {
+            name: "msg4",
+            type: "testapis.options.deprecation.NotDeprecatedMessage.InnerMessage2",
+          },
+        ],
       },
     },
   },

--- a/tests/golden/ts-proto/testapis.options.field_nullability/__expected__/testapis/options/field_nullability/field_nullability.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.options.field_nullability/__expected__/testapis/options/field_nullability/field_nullability.pb.pothos.ts
@@ -63,8 +63,10 @@ builder.objectType(Message$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as Message | { $type: string & {}; }).$type ===
-      "testapis.options.field_nullability.Message";
+    return (
+      (source as Message | { $type: string & {} }).$type ===
+      "testapis.options.field_nullability.Message"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -82,7 +84,8 @@ export type MessageInput$Shape = {
 };
 
 export const MessageInput$Ref: InputObjectRef<MessageInput$Shape> = builder
-  .inputRef<MessageInput$Shape>("MessageInput").implement({
+  .inputRef<MessageInput$Shape>("MessageInput")
+  .implement({
     fields: (t) => ({
       userId: t.field({
         type: "String",

--- a/tests/golden/ts-proto/testapis.options.input_no_partial/__expected__/testapis/options/input_no_partial/input_no_partial.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.options.input_no_partial/__expected__/testapis/options/input_no_partial/input_no_partial.pb.pothos.ts
@@ -10,9 +10,8 @@ import {
 } from "@proto-graphql/e2e-testapis-ts-proto/lib/testapis/options/input_no_partial/input_no_partial";
 import { InputObjectRef } from "@pothos/core";
 
-export const ParentMessage$Ref = builder.objectRef<ParentMessage>(
-  "ParentMessage",
-);
+export const ParentMessage$Ref =
+  builder.objectRef<ParentMessage>("ParentMessage");
 builder.objectType(ParentMessage$Ref, {
   name: "ParentMessage",
   fields: (t) => ({
@@ -48,8 +47,10 @@ builder.objectType(ParentMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as ParentMessage | { $type: string & {}; }).$type ===
-      "testapis.options.input_no_partial.ParentMessage";
+    return (
+      (source as ParentMessage | { $type: string & {} }).$type ===
+      "testapis.options.input_no_partial.ParentMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -60,9 +61,8 @@ builder.objectType(ParentMessage$Ref, {
   },
 });
 
-export const PartialableInputMessage$Ref = builder.objectRef<
-  PartialableInputMessage
->("PartialableInputMessage");
+export const PartialableInputMessage$Ref =
+  builder.objectRef<PartialableInputMessage>("PartialableInputMessage");
 builder.objectType(PartialableInputMessage$Ref, {
   name: "PartialableInputMessage",
   fields: (t) => ({
@@ -80,8 +80,10 @@ builder.objectType(PartialableInputMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as PartialableInputMessage | { $type: string & {}; })
-      .$type === "testapis.options.input_no_partial.PartialableInputMessage";
+    return (
+      (source as PartialableInputMessage | { $type: string & {} }).$type ===
+      "testapis.options.input_no_partial.PartialableInputMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -92,9 +94,8 @@ builder.objectType(PartialableInputMessage$Ref, {
   },
 });
 
-export const NoPartialInputMessage$Ref = builder.objectRef<
-  NoPartialInputMessage
->("NoPartialInputMessage");
+export const NoPartialInputMessage$Ref =
+  builder.objectRef<NoPartialInputMessage>("NoPartialInputMessage");
 builder.objectType(NoPartialInputMessage$Ref, {
   name: "NoPartialInputMessage",
   fields: (t) => ({
@@ -112,8 +113,10 @@ builder.objectType(NoPartialInputMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as NoPartialInputMessage | { $type: string & {}; }).$type ===
-      "testapis.options.input_no_partial.NoPartialInputMessage";
+    return (
+      (source as NoPartialInputMessage | { $type: string & {} }).$type ===
+      "testapis.options.input_no_partial.NoPartialInputMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -131,105 +134,111 @@ export type ParentMessageInput$Shape = {
 };
 
 export const ParentMessageInput$Ref: InputObjectRef<ParentMessageInput$Shape> =
-  builder.inputRef<ParentMessageInput$Shape>("ParentMessageInput").implement({
-    fields: (t) => ({
-      partialableInputMessage: t.field({
-        type: PartialableInputMessageInput$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "partialable_input_message",
-            typeFullName:
-              "testapis.options.input_no_partial.PartialableInputMessage",
+  builder
+    .inputRef<ParentMessageInput$Shape>("ParentMessageInput")
+    .implement({
+      fields: (t) => ({
+        partialableInputMessage: t.field({
+          type: PartialableInputMessageInput$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "partialable_input_message",
+              typeFullName:
+                "testapis.options.input_no_partial.PartialableInputMessage",
+            },
           },
-        },
-      }),
-      noPartialInputMessage: t.field({
-        type: NoPartialInputMessageInput$Ref,
-        required: true,
-        description: "Required.",
-        extensions: {
-          protobufField: {
-            name: "no_partial_input_message",
-            typeFullName:
-              "testapis.options.input_no_partial.NoPartialInputMessage",
+        }),
+        noPartialInputMessage: t.field({
+          type: NoPartialInputMessageInput$Ref,
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: {
+              name: "no_partial_input_message",
+              typeFullName:
+                "testapis.options.input_no_partial.NoPartialInputMessage",
+            },
           },
-        },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.input_no_partial.ParentMessage",
-        name: "ParentMessage",
-        package: "testapis.options.input_no_partial",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.input_no_partial.ParentMessage",
+          name: "ParentMessage",
+          package: "testapis.options.input_no_partial",
+        },
       },
-    },
-  });
+    });
 
 export type PartialableInputMessageInput$Shape = {
   id: PartialableInputMessage["id"];
   body: PartialableInputMessage["body"];
 };
 
-export const PartialableInputMessageInput$Ref: InputObjectRef<
-  PartialableInputMessageInput$Shape
-> = builder.inputRef<PartialableInputMessageInput$Shape>(
-  "PartialableInputMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.input_no_partial.PartialableInputMessage",
-      name: "PartialableInputMessage",
-      package: "testapis.options.input_no_partial",
-    },
-  },
-});
+export const PartialableInputMessageInput$Ref: InputObjectRef<PartialableInputMessageInput$Shape> =
+  builder
+    .inputRef<PartialableInputMessageInput$Shape>(
+      "PartialableInputMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          description: "Required.",
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.input_no_partial.PartialableInputMessage",
+          name: "PartialableInputMessage",
+          package: "testapis.options.input_no_partial",
+        },
+      },
+    });
 
 export type NoPartialInputMessageInput$Shape = {
   id: NoPartialInputMessage["id"];
   body: NoPartialInputMessage["body"];
 };
 
-export const NoPartialInputMessageInput$Ref: InputObjectRef<
-  NoPartialInputMessageInput$Shape
-> = builder.inputRef<NoPartialInputMessageInput$Shape>(
-  "NoPartialInputMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      description: "Required.",
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.input_no_partial.NoPartialInputMessage",
-      name: "NoPartialInputMessage",
-      package: "testapis.options.input_no_partial",
-      options: { "[graphql.input_type]": { noPartial: true } },
-    },
-  },
-});
+export const NoPartialInputMessageInput$Ref: InputObjectRef<NoPartialInputMessageInput$Shape> =
+  builder
+    .inputRef<NoPartialInputMessageInput$Shape>("NoPartialInputMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          description: "Required.",
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          description: "Required.",
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.input_no_partial.NoPartialInputMessage",
+          name: "NoPartialInputMessage",
+          package: "testapis.options.input_no_partial",
+          options: { "[graphql.input_type]": { noPartial: true } },
+        },
+      },
+    });

--- a/tests/golden/ts-proto/testapis.options.message_and_field/__expected__/testapis/options/message_and_field/message_and_field.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.options.message_and_field/__expected__/testapis/options/message_and_field/message_and_field.pb.pothos.ts
@@ -17,9 +17,8 @@ import {
 } from "@proto-graphql/e2e-testapis-ts-proto/lib/testapis/options/message_and_field/message_and_field";
 import { EnumRef, InputObjectRef } from "@pothos/core";
 
-export const PrefixedMessage$Ref = builder.objectRef<PrefixedMessage>(
-  "PrefixedMessage",
-);
+export const PrefixedMessage$Ref =
+  builder.objectRef<PrefixedMessage>("PrefixedMessage");
 builder.objectType(PrefixedMessage$Ref, {
   name: "PrefixedMessage",
   fields: (t) => ({
@@ -86,7 +85,8 @@ builder.objectType(PrefixedMessage$Ref, {
       type: PrefixedMessageSquashedMessage$Ref,
       nullable: true,
       resolve: (source) => {
-        const value = source.squashedMessage?.oneofField ??
+        const value =
+          source.squashedMessage?.oneofField ??
           source.squashedMessage?.oneofField2;
         if (value == null) {
           return null;
@@ -175,8 +175,10 @@ builder.objectType(PrefixedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as PrefixedMessage | { $type: string & {}; }).$type ===
-      "testapis.options.message_and_field.PrefixedMessage";
+    return (
+      (source as PrefixedMessage | { $type: string & {} }).$type ===
+      "testapis.options.message_and_field.PrefixedMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -187,9 +189,8 @@ builder.objectType(PrefixedMessage$Ref, {
   },
 });
 
-export const RenamedMessage$Ref = builder.objectRef<MessageWillRename>(
-  "RenamedMessage",
-);
+export const RenamedMessage$Ref =
+  builder.objectRef<MessageWillRename>("RenamedMessage");
 builder.objectType(RenamedMessage$Ref, {
   name: "RenamedMessage",
   fields: (t) => ({
@@ -200,8 +201,10 @@ builder.objectType(RenamedMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as MessageWillRename | { $type: string & {}; }).$type ===
-      "testapis.options.message_and_field.MessageWillRename";
+    return (
+      (source as MessageWillRename | { $type: string & {} }).$type ===
+      "testapis.options.message_and_field.MessageWillRename"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -213,9 +216,8 @@ builder.objectType(RenamedMessage$Ref, {
   },
 });
 
-export const MessageOnlyOutput$Ref = builder.objectRef<MessageOnlyOutput>(
-  "MessageOnlyOutput",
-);
+export const MessageOnlyOutput$Ref =
+  builder.objectRef<MessageOnlyOutput>("MessageOnlyOutput");
 builder.objectType(MessageOnlyOutput$Ref, {
   name: "MessageOnlyOutput",
   fields: (t) => ({
@@ -226,8 +228,10 @@ builder.objectType(MessageOnlyOutput$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as MessageOnlyOutput | { $type: string & {}; }).$type ===
-      "testapis.options.message_and_field.MessageOnlyOutput";
+    return (
+      (source as MessageOnlyOutput | { $type: string & {} }).$type ===
+      "testapis.options.message_and_field.MessageOnlyOutput"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -239,9 +243,10 @@ builder.objectType(MessageOnlyOutput$Ref, {
   },
 });
 
-export const PrefixedMessageInnerMessage$Ref = builder.objectRef<
-  PrefixedMessage_InnerMessage
->("PrefixedMessageInnerMessage");
+export const PrefixedMessageInnerMessage$Ref =
+  builder.objectRef<PrefixedMessage_InnerMessage>(
+    "PrefixedMessageInnerMessage",
+  );
 builder.objectType(PrefixedMessageInnerMessage$Ref, {
   name: "PrefixedMessageInnerMessage",
   fields: (t) => ({
@@ -257,9 +262,11 @@ builder.objectType(PrefixedMessageInnerMessage$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as PrefixedMessage_InnerMessage | { $type: string & {}; })
-      .$type ===
-      "testapis.options.message_and_field.PrefixedMessage.InnerMessage";
+    return (
+      (source as PrefixedMessage_InnerMessage | { $type: string & {} })
+        .$type ===
+      "testapis.options.message_and_field.PrefixedMessage.InnerMessage"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -271,9 +278,10 @@ builder.objectType(PrefixedMessageInnerMessage$Ref, {
   },
 });
 
-export const PrefixedMessageInnerMessage2$Ref = builder.objectRef<
-  PrefixedMessage_InnerMessage2
->("PrefixedMessageInnerMessage2");
+export const PrefixedMessageInnerMessage2$Ref =
+  builder.objectRef<PrefixedMessage_InnerMessage2>(
+    "PrefixedMessageInnerMessage2",
+  );
 builder.objectType(PrefixedMessageInnerMessage2$Ref, {
   name: "PrefixedMessageInnerMessage2",
   fields: (t) => ({
@@ -289,9 +297,11 @@ builder.objectType(PrefixedMessageInnerMessage2$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as PrefixedMessage_InnerMessage2 | { $type: string & {}; })
-      .$type ===
-      "testapis.options.message_and_field.PrefixedMessage.InnerMessage2";
+    return (
+      (source as PrefixedMessage_InnerMessage2 | { $type: string & {} })
+        .$type ===
+      "testapis.options.message_and_field.PrefixedMessage.InnerMessage2"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -303,9 +313,8 @@ builder.objectType(PrefixedMessageInnerMessage2$Ref, {
   },
 });
 
-export const IgnoredMessageNotIgnored$Ref = builder.objectRef<
-  IgnoredMessage_NotIgnored
->("IgnoredMessageNotIgnored");
+export const IgnoredMessageNotIgnored$Ref =
+  builder.objectRef<IgnoredMessage_NotIgnored>("IgnoredMessageNotIgnored");
 builder.objectType(IgnoredMessageNotIgnored$Ref, {
   name: "IgnoredMessageNotIgnored",
   fields: (t) => ({
@@ -316,8 +325,10 @@ builder.objectType(IgnoredMessageNotIgnored$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as IgnoredMessage_NotIgnored | { $type: string & {}; })
-      .$type === "testapis.options.message_and_field.IgnoredMessage.NotIgnored";
+    return (
+      (source as IgnoredMessage_NotIgnored | { $type: string & {} }).$type ===
+      "testapis.options.message_and_field.IgnoredMessage.NotIgnored"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -342,317 +353,335 @@ export type PrefixedMessageInput$Shape = {
   squashedMessages?: Array<PrefixedMessageSquashedMessageInput$Shape> | null;
 };
 
-export const PrefixedMessageInput$Ref: InputObjectRef<
-  PrefixedMessageInput$Shape
-> = builder.inputRef<PrefixedMessageInput$Shape>("PrefixedMessageInput")
-  .implement({
-    fields: (t) => ({
-      id: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "id",
-            typeFullName: "uint64",
-            options: { "[graphql.field]": { id: true } },
+export const PrefixedMessageInput$Ref: InputObjectRef<PrefixedMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInput$Shape>("PrefixedMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "id",
+              typeFullName: "uint64",
+              options: { "[graphql.field]": { id: true } },
+            },
           },
-        },
-      }),
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
-      }),
-      prefixedEnum: t.field({
-        type: PrefixedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "prefixed_enum",
-            typeFullName: "testapis.options.message_and_field.PrefixedEnum",
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
           },
-        },
-      }),
-      thisFieldWasRenamed: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "this_field_will_be_renamed",
-            typeFullName: "string",
-            options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
+        }),
+        prefixedEnum: t.field({
+          type: PrefixedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "prefixed_enum",
+              typeFullName: "testapis.options.message_and_field.PrefixedEnum",
+            },
           },
-        },
-      }),
-      skipResolver: t.field({
-        type: "String",
-        required: true,
-        extensions: {
-          protobufField: {
-            name: "skip_resolver",
-            typeFullName: "string",
-            options: { "[graphql.field]": { skipResolver: true } },
+        }),
+        thisFieldWasRenamed: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "this_field_will_be_renamed",
+              typeFullName: "string",
+              options: { "[graphql.field]": { name: "thisFieldWasRenamed" } },
+            },
           },
-        },
-      }),
-      squashedMessage: t.field({
-        type: PrefixedMessageSquashedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "squashed_message",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+        }),
+        skipResolver: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: {
+              name: "skip_resolver",
+              typeFullName: "string",
+              options: { "[graphql.field]": { skipResolver: true } },
+            },
           },
-        },
-      }),
-      renamedMessage: t.field({
-        type: RenamedMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "renamed_message",
-            typeFullName:
-              "testapis.options.message_and_field.MessageWillRename",
+        }),
+        squashedMessage: t.field({
+          type: PrefixedMessageSquashedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "squashed_message",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
           },
-        },
-      }),
-      renamedEnum: t.field({
-        type: RenamedEnum$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "renamed_enum",
-            typeFullName: "testapis.options.message_and_field.EnumWillRename",
+        }),
+        renamedMessage: t.field({
+          type: RenamedMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_message",
+              typeFullName:
+                "testapis.options.message_and_field.MessageWillRename",
+            },
           },
-        },
-      }),
-      notIgnoredMessage: t.field({
-        type: IgnoredMessageNotIgnoredInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "not_ignored_message",
-            typeFullName:
-              "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+        }),
+        renamedEnum: t.field({
+          type: RenamedEnum$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "renamed_enum",
+              typeFullName: "testapis.options.message_and_field.EnumWillRename",
+            },
           },
-        },
-      }),
-      oneofNotIgnoredField: t.field({
-        type: PrefixedMessageInnerMessageInput$Ref,
-        required: false,
-        extensions: {
-          protobufField: {
-            name: "oneof_not_ignored_field",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+        }),
+        notIgnoredMessage: t.field({
+          type: IgnoredMessageNotIgnoredInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "not_ignored_message",
+              typeFullName:
+                "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+            },
           },
-        },
-      }),
-      squashedMessages: t.field({
-        type: [PrefixedMessageSquashedMessageInput$Ref],
-        required: { list: false, items: true },
-        extensions: {
-          protobufField: {
-            name: "squashed_messages",
-            typeFullName:
-              "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+        }),
+        oneofNotIgnoredField: t.field({
+          type: PrefixedMessageInnerMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_not_ignored_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
           },
-        },
+        }),
+        squashedMessages: t.field({
+          type: [PrefixedMessageSquashedMessageInput$Ref],
+          required: { list: false, items: true },
+          extensions: {
+            protobufField: {
+              name: "squashed_messages",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+            },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.PrefixedMessage",
-        name: "PrefixedMessage",
-        package: "testapis.options.message_and_field",
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.PrefixedMessage",
+          name: "PrefixedMessage",
+          package: "testapis.options.message_and_field",
+        },
       },
-    },
-  });
+    });
 
-export type RenamedMessageInput$Shape = { body: MessageWillRename["body"]; };
+export type RenamedMessageInput$Shape = {
+  body: MessageWillRename["body"];
+};
 
-export const RenamedMessageInput$Ref: InputObjectRef<
-  RenamedMessageInput$Shape
-> = builder.inputRef<RenamedMessageInput$Shape>("RenamedMessageInput")
-  .implement({
-    fields: (t) => ({
-      body: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "body", typeFullName: "string" } },
+export const RenamedMessageInput$Ref: InputObjectRef<RenamedMessageInput$Shape> =
+  builder
+    .inputRef<RenamedMessageInput$Shape>("RenamedMessageInput")
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.MessageWillRename",
-        name: "MessageWillRename",
-        package: "testapis.options.message_and_field",
-        options: { "[graphql.object_type]": { name: "RenamedMessage" } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.MessageWillRename",
+          name: "MessageWillRename",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { name: "RenamedMessage" } },
+        },
       },
-    },
-  });
+    });
 
-export type InterfaceMessageInput$Shape = { id: InterfaceMessage["id"]; };
+export type InterfaceMessageInput$Shape = {
+  id: InterfaceMessage["id"];
+};
 
-export const InterfaceMessageInput$Ref: InputObjectRef<
-  InterfaceMessageInput$Shape
-> = builder.inputRef<InterfaceMessageInput$Shape>("InterfaceMessageInput")
-  .implement({
-    fields: (t) => ({
-      id: t.field({
-        type: "String",
-        required: true,
-        extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+export const InterfaceMessageInput$Ref: InputObjectRef<InterfaceMessageInput$Shape> =
+  builder
+    .inputRef<InterfaceMessageInput$Shape>("InterfaceMessageInput")
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
       }),
-    }),
-    extensions: {
-      protobufMessage: {
-        fullName: "testapis.options.message_and_field.InterfaceMessage",
-        name: "InterfaceMessage",
-        package: "testapis.options.message_and_field",
-        options: { "[graphql.object_type]": { interface: true } },
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.message_and_field.InterfaceMessage",
+          name: "InterfaceMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { interface: true } },
+        },
       },
-    },
-  });
+    });
 
 export type PrefixedMessageInnerMessageInput$Shape = {
   id: PrefixedMessage_InnerMessage["id"];
   body: PrefixedMessage_InnerMessage["body"];
 };
 
-export const PrefixedMessageInnerMessageInput$Ref: InputObjectRef<
-  PrefixedMessageInnerMessageInput$Shape
-> = builder.inputRef<PrefixedMessageInnerMessageInput$Shape>(
-  "PrefixedMessageInnerMessageInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-      name: "InnerMessage",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const PrefixedMessageInnerMessageInput$Ref: InputObjectRef<PrefixedMessageInnerMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessageInput$Shape>(
+      "PrefixedMessageInnerMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+          name: "InnerMessage",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export type PrefixedMessageInnerMessage2Input$Shape = {
   id: PrefixedMessage_InnerMessage2["id"];
   body: PrefixedMessage_InnerMessage2["body"];
 };
 
-export const PrefixedMessageInnerMessage2Input$Ref: InputObjectRef<
-  PrefixedMessageInnerMessage2Input$Shape
-> = builder.inputRef<PrefixedMessageInnerMessage2Input$Shape>(
-  "PrefixedMessageInnerMessage2Input",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-      name: "InnerMessage2",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const PrefixedMessageInnerMessage2Input$Ref: InputObjectRef<PrefixedMessageInnerMessage2Input$Shape> =
+  builder
+    .inputRef<PrefixedMessageInnerMessage2Input$Shape>(
+      "PrefixedMessageInnerMessage2Input",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+          name: "InnerMessage2",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
 export type PrefixedMessageSquashedMessageInput$Shape = {
   oneofField?: PrefixedMessageInnerMessageInput$Shape | null;
   oneofField2?: PrefixedMessageInnerMessage2Input$Shape | null;
 };
 
-export const PrefixedMessageSquashedMessageInput$Ref: InputObjectRef<
-  PrefixedMessageSquashedMessageInput$Shape
-> = builder.inputRef<PrefixedMessageSquashedMessageInput$Shape>(
-  "PrefixedMessageSquashedMessageInput",
-).implement({
-  fields: (t) => ({
-    oneofField: t.field({
-      type: PrefixedMessageInnerMessageInput$Ref,
-      required: false,
+export const PrefixedMessageSquashedMessageInput$Ref: InputObjectRef<PrefixedMessageSquashedMessageInput$Shape> =
+  builder
+    .inputRef<PrefixedMessageSquashedMessageInput$Shape>(
+      "PrefixedMessageSquashedMessageInput",
+    )
+    .implement({
+      fields: (t) => ({
+        oneofField: t.field({
+          type: PrefixedMessageInnerMessageInput$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            },
+          },
+        }),
+        oneofField2: t.field({
+          type: PrefixedMessageInnerMessage2Input$Ref,
+          required: false,
+          extensions: {
+            protobufField: {
+              name: "oneof_field_2",
+              typeFullName:
+                "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            },
+          },
+        }),
+      }),
       extensions: {
-        protobufField: {
-          name: "oneof_field",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
+          name: "SquashedMessage",
+          package: "testapis.options.message_and_field",
+          options: { "[graphql.object_type]": { squashUnion: true } },
         },
       },
-    }),
-    oneofField2: t.field({
-      type: PrefixedMessageInnerMessage2Input$Ref,
-      required: false,
-      extensions: {
-        protobufField: {
-          name: "oneof_field_2",
-          typeFullName:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-        },
-      },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName:
-        "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
-      name: "SquashedMessage",
-      package: "testapis.options.message_and_field",
-      options: { "[graphql.object_type]": { squashUnion: true } },
-    },
-  },
-});
+    });
 
 export type IgnoredMessageNotIgnoredInput$Shape = {
   body: IgnoredMessage_NotIgnored["body"];
 };
 
-export const IgnoredMessageNotIgnoredInput$Ref: InputObjectRef<
-  IgnoredMessageNotIgnoredInput$Shape
-> = builder.inputRef<IgnoredMessageNotIgnoredInput$Shape>(
-  "IgnoredMessageNotIgnoredInput",
-).implement({
-  fields: (t) => ({
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
-      name: "NotIgnored",
-      package: "testapis.options.message_and_field",
-    },
-  },
-});
+export const IgnoredMessageNotIgnoredInput$Ref: InputObjectRef<IgnoredMessageNotIgnoredInput$Shape> =
+  builder
+    .inputRef<IgnoredMessageNotIgnoredInput$Shape>(
+      "IgnoredMessageNotIgnoredInput",
+    )
+    .implement({
+      fields: (t) => ({
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName:
+            "testapis.options.message_and_field.IgnoredMessage.NotIgnored",
+          name: "NotIgnored",
+          package: "testapis.options.message_and_field",
+        },
+      },
+    });
 
-export const InterfaceMessage$Ref = builder.interfaceRef<
-  Pick<InterfaceMessage, "id">
->("InterfaceMessage");
+export const InterfaceMessage$Ref =
+  builder.interfaceRef<Pick<InterfaceMessage, "id">>("InterfaceMessage");
 builder.interfaceType(InterfaceMessage$Ref, {
   name: "InterfaceMessage",
   fields: (t) => ({
@@ -682,17 +711,18 @@ export const PrefixedMessageSquashedMessage$Ref = builder.unionType(
           "testapis.options.message_and_field.PrefixedMessage.SquashedMessage",
         name: "SquashedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }, {
-          name: "oneof_field_2",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
-          options: { "[graphql.object_type]": { squashUnion: true } },
-        }],
+        fields: [
+          {
+            name: "oneof_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+          {
+            name: "oneof_field_2",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage2",
+            options: { "[graphql.object_type]": { squashUnion: true } },
+          },
+        ],
       },
     },
   },
@@ -709,18 +739,19 @@ export const PrefixedMessagePartialIgnoreOneof$Ref = builder.unionType(
         name: "partial_ignore_oneof",
         messageName: "PrefixedMessage",
         package: "testapis.options.message_and_field",
-        fields: [{
-          name: "oneof_not_ignored_field",
-          type:
-            "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
-        }],
+        fields: [
+          {
+            name: "oneof_not_ignored_field",
+            type: "testapis.options.message_and_field.PrefixedMessage.InnerMessage",
+          },
+        ],
       },
     },
   },
 );
 
-export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> = builder
-  .enumType("RenamedEnum", {
+export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> =
+  builder.enumType("RenamedEnum", {
     values: {
       FOO: {
         value: 1,
@@ -741,8 +772,8 @@ export const RenamedEnum$Ref: EnumRef<EnumWillRename, EnumWillRename> = builder
     },
   });
 
-export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> = builder
-  .enumType("PrefixedEnum", {
+export const PrefixedEnum$Ref: EnumRef<PrefixedEnum, PrefixedEnum> =
+  builder.enumType("PrefixedEnum", {
     values: {
       PREFIXED_FOO: {
         value: 1,

--- a/tests/golden/ts-proto/testapis.options.schema/__expected__/testapis/options/schema/schema.pb.pothos.ts
+++ b/tests/golden/ts-proto/testapis.options.schema/__expected__/testapis/options/schema/schema.pb.pothos.ts
@@ -24,8 +24,10 @@ builder.objectType(SchemaPrefixPostResponse$Ref, {
     }),
   }),
   isTypeOf: (source) => {
-    return (source as PostResponse | { $type: string & {}; }).$type ===
-      "testapis.options.schema.PostResponse";
+    return (
+      (source as PostResponse | { $type: string & {} }).$type ===
+      "testapis.options.schema.PostResponse"
+    );
   },
   extensions: {
     protobufMessage: {
@@ -41,28 +43,31 @@ export type SchemaPrefixPostResponseInput$Shape = {
   body: PostResponse["body"];
 };
 
-export const SchemaPrefixPostResponseInput$Ref: InputObjectRef<
-  SchemaPrefixPostResponseInput$Shape
-> = builder.inputRef<SchemaPrefixPostResponseInput$Shape>(
-  "SchemaPrefixPostResponseInput",
-).implement({
-  fields: (t) => ({
-    id: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
-    }),
-    body: t.field({
-      type: "String",
-      required: true,
-      extensions: { protobufField: { name: "body", typeFullName: "string" } },
-    }),
-  }),
-  extensions: {
-    protobufMessage: {
-      fullName: "testapis.options.schema.PostResponse",
-      name: "PostResponse",
-      package: "testapis.options.schema",
-    },
-  },
-});
+export const SchemaPrefixPostResponseInput$Ref: InputObjectRef<SchemaPrefixPostResponseInput$Shape> =
+  builder
+    .inputRef<SchemaPrefixPostResponseInput$Shape>(
+      "SchemaPrefixPostResponseInput",
+    )
+    .implement({
+      fields: (t) => ({
+        id: t.field({
+          type: "String",
+          required: true,
+          extensions: { protobufField: { name: "id", typeFullName: "uint64" } },
+        }),
+        body: t.field({
+          type: "String",
+          required: true,
+          extensions: {
+            protobufField: { name: "body", typeFullName: "string" },
+          },
+        }),
+      }),
+      extensions: {
+        protobufMessage: {
+          fullName: "testapis.options.schema.PostResponse",
+          name: "PostResponse",
+          package: "testapis.options.schema",
+        },
+      },
+    });


### PR DESCRIPTION
## Why

PR #512 closed the `findComments` O(N²) hot path (#511); afterwards #514 documented `formatCode` (the `dprint-node` call in `src/codegen/stringify.ts`) as the next dominant cost — ~70 % CPU self time on a synthetic 400 × 20 fixture. This PR explores option (2) from #514: swap `dprint-node` for the faster `oxfmt`.

It is filed as a **draft** because it is being weighed against an alternative (a `format=false` plugin option to skip formatting entirely; see follow-up PR). Final direction depends on whether the snapshot-style churn here is acceptable.

## What

- `src/codegen/stringify.ts` — replace `dprint-node` with a sync wrapper around `oxfmt.format` via `synckit`.
- `src/codegen/stringify-worker.mjs` (new) — plain ESM worker calling `oxfmt.format`. `.mjs` rather than `.ts` because Node 22's `worker_threads` does not inherit tsx's TS loader, and `oxfmt` only exposes ESM.
- `tsup.config.ts` becomes per-package and copies the worker `.mjs` into `dist/codegen/` so the runtime resolver finds it next to the built entry.
- `plugin.ts`, `protoc-gen-pothos.ts`, and the golden test runner remain unchanged. `formatCode` keeps the same `(string) => string` shape, so `@bufbuild/protoplugin`'s `runNodeJs(plugin)` and synchronous `plugin.run(req)` contracts are preserved.
- `dprint-node` is dropped from `dependencies`; `oxfmt` and `synckit` are added.

Prettier-style options match the previous dprint options where there is a direct equivalent. Differences in line-wrapping and method-chain layout are unavoidable because dprint and Prettier use different formatting algorithms.

## Performance

Synthetic fixture (`tmp-profile/`, not committed), 5 iterations average:

| size (messages × fields) | before (dprint) | after (oxfmt + synckit) | speedup |
| --- | ---: | ---: | ---: |
| 10 × 10 (100 fields)     | 11 ms  |  6 ms  | 1.9× |
| 25 × 20 (500 fields)     | 37 ms  | 21 ms  | 1.7× |
| 50 × 20 (1 000 fields)   | 76 ms  | 48 ms  | 1.6× |
| 100 × 20 (2 000 fields)  | 158 ms | 80 ms  | 2.0× |
| 200 × 20 (4 000 fields)  | 329 ms | 166 ms | 2.0× |
| 400 × 20 (8 000 fields)  | 698 ms | **345 ms** | **2.0×** |

`ms / field` drops from ~0.08 to ~0.04 across the range.

CPU profile on the 400 × 20 fixture:

|  | before (dprint) | after (oxfmt + synckit) |
| --- | ---: | ---: |
| total main-thread CPU | 9.1 s | 4.9 s |
| top JS self time | `formatCode` (dprint) **69 %** | `receiveMessageWithId` (`Atomics.wait`) **41 %** |

The 41 % `receiveMessageWithId` is the main thread blocking on the worker — the inherent cost of providing a sync API (required by protoplugin) on top of an async formatter. The pure formatter step itself is ~8× faster than dprint; the worker round-trip costs ~1 ms per file, which is what limits us to ~2× end-to-end.

## Notes for reviewers

- **Snapshot diff is large but style-only** (~12 000 lines across ~80 files): method-chain wrap position and generic-argument placement are different because Prettier and dprint use fundamentally different layout algorithms. Verified via spot-diff on `testapis.behavior.field_comments` — SDL, generated descriptions, `description: "Required."` etc. are all preserved.
- **Worker is shipped as `.mjs` source** plus a tsup `onSuccess` `copyFile` into `dist/codegen/`. tsup's bundler can't traverse `new Worker(...)` so we sidestep the bundle. The `import.meta.url` resolver in `stringify.ts` walks two candidate paths so the same code works for built (`dist/codegen/stringify-worker.mjs`) and dev/test (`src/codegen/stringify-worker.mjs`) loads.
- **`// @ts-ignore` on `import.meta.url`** bridges this package's `module: commonjs` tsconfig (used only for declaration emit; rejects the syntax) and the runtime where tsup emits both CJS and ESM with the right transform. `@ts-expect-error` would itself error under the root tsconfig (`module: esnext`).
- **6 pre-existing test failures** in `tests/golden/*/testapis.oneof/` (orphan dirs left over from the e2e → golden migration, missing `schema.ts`) are unaffected by this PR; they fail on `main` too.

## Out-of-scope follow-ups

- Batch all files into a single worker round-trip per `plugin.run` (would cut the per-file ~1 ms synckit overhead).
- Worker pool (synckit currently uses one worker) for parallel formatting of large file sets.
- The alternative explored in the sibling PR: a `format=false` plugin option to skip the in-plugin format step entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)