### PR TITLE
feat(protoc-gen-pothos): add `format` option to skip in-plugin formatter

### DIFF
--- a/.changeset/feat-protoc-gen-pothos-format-option.md
+++ b/.changeset/feat-protoc-gen-pothos-format-option.md
@@ -1,0 +1,5 @@
+---
+"protoc-gen-pothos": minor
+---
+
+feat: add `format` plugin option (default true) to skip the in-plugin formatter pass

--- a/packages/@proto-graphql/protoc-plugin-helpers/src/options.test.ts
+++ b/packages/@proto-graphql/protoc-plugin-helpers/src/options.test.ts
@@ -57,15 +57,15 @@ describe("parsePothosOptions", () => {
   });
 
   it("parses format=false", () => {
-    expect(
-      parsePothosOptions([{ key: "format", value: "false" }]).format,
-    ).toBe(false);
+    expect(parsePothosOptions([{ key: "format", value: "false" }]).format).toBe(
+      false,
+    );
   });
 
   it("parses format=true explicitly", () => {
-    expect(
-      parsePothosOptions([{ key: "format", value: "true" }]).format,
-    ).toBe(true);
+    expect(parsePothosOptions([{ key: "format", value: "true" }]).format).toBe(
+      true,
+    );
   });
 
   it("throws on non-bool format value", () => {

--- a/packages/@proto-graphql/protoc-plugin-helpers/src/options.test.ts
+++ b/packages/@proto-graphql/protoc-plugin-helpers/src/options.test.ts
@@ -51,4 +51,26 @@ describe("parsePothosOptions", () => {
       "./builder",
     );
   });
+
+  it("defaults format to true", () => {
+    expect(parsePothosOptions([]).format).toBe(true);
+  });
+
+  it("parses format=false", () => {
+    expect(
+      parsePothosOptions([{ key: "format", value: "false" }]).format,
+    ).toBe(false);
+  });
+
+  it("parses format=true explicitly", () => {
+    expect(
+      parsePothosOptions([{ key: "format", value: "true" }]).format,
+    ).toBe(true);
+  });
+
+  it("throws on non-bool format value", () => {
+    expect(() =>
+      parsePothosOptions([{ key: "format", value: "maybe" }]),
+    ).toThrow(/format should be bool/);
+  });
 });

--- a/packages/@proto-graphql/protoc-plugin-helpers/src/options.ts
+++ b/packages/@proto-graphql/protoc-plugin-helpers/src/options.ts
@@ -9,6 +9,12 @@ import {
 export type Options<DSL extends PrinterOptions["dsl"]> = {
   type: TypeOptions;
   printer: Extract<PrinterOptions, { dsl: DSL }>;
+  /**
+   * When false, skip the in-plugin formatter pass over the generated
+   * TypeScript. Useful when downstream tooling (Biome / Prettier) will format
+   * the output anyway. Defaults to true.
+   */
+  format: boolean;
 };
 
 export function parsePothosOptions(
@@ -28,6 +34,7 @@ export function parsePothosOptions(
       filenameSuffix: ".pb.pothos.ts",
       pothos: { builderPath: "./builder" },
     } as Extract<PrinterOptions, { dsl: "pothos" }>,
+    format: true,
   };
 
   const boolParam = (name: string, v: string): boolean => {
@@ -86,6 +93,10 @@ export function parsePothosOptions(
       }
       case "ignore_non_message_oneof_fields": {
         params.type.ignoreNonMessageOneofFields = true;
+        break;
+      }
+      case "format": {
+        params.format = boolParam(k, v);
         break;
       }
       case "target":

--- a/packages/protoc-gen-pothos/src/plugin.ts
+++ b/packages/protoc-gen-pothos/src/plugin.ts
@@ -1,6 +1,7 @@
-import { createEcmaScriptPlugin } from "@bufbuild/protoplugin";
+import { createEcmaScriptPlugin, type Schema } from "@bufbuild/protoplugin";
 import {
   createTsGenerator,
+  type Options,
   parsePothosOptions,
 } from "@proto-graphql/protoc-plugin-helpers";
 
@@ -8,16 +9,29 @@ import { version } from "../package.json";
 import { formatCode } from "./codegen/stringify.js";
 import { generateFiles } from "./printer.js";
 
+const baseGenerateTs = createTsGenerator({
+  generateFiles,
+  dsl: "pothos",
+});
+
+// `transpile` does not receive the parsed plugin options, so capture the
+// `format` flag here when `generateTs` runs (which sees `schema.options`).
+// One `plugin.run(req)` is one logical request, and protoplugin invokes
+// `generateTs` before `transpile`, so this single-slot state is safe within
+// a request.
+let formatEnabled = true;
+
 export const protocGenPothos = createEcmaScriptPlugin({
   name: "protoc-gen-pothos",
   version: `v${version}`,
-  generateTs: createTsGenerator({
-    generateFiles,
-    dsl: "pothos",
-  }),
+  generateTs: (schema: Schema<Partial<Options<"pothos">>>) => {
+    formatEnabled = schema.options.format !== false;
+    return baseGenerateTs(schema as Schema<Options<"pothos">>);
+  },
   parseOptions: parsePothosOptions,
   // NOTE: force `target=ts` and apply formatting
   transpile: (files) => {
+    if (!formatEnabled) return files;
     return files.map((f) => ({
       ...f,
       content: formatCode(f.content),


### PR DESCRIPTION
## Why

PR #512 closed the `findComments` O(N²) hot path (#511); afterwards #514 documented `formatCode` (the `dprint-node` call in `src/codegen/stringify.ts`) as the next dominant CPU cost — ~70 % self time on a synthetic 400 × 20 fixture. Two non-mutually-exclusive directions were proposed in #514:

1. **Make formatting opt-out via a plugin option** (this PR) — smallest surface change, biggest single-knob win for users who already format generated code with Biome/Prettier downstream.
2. Swap `dprint-node` for a faster formatter (sibling draft PR #516) — keeps the in-plugin format, ~2 × faster overall.

Most downstream users run their own formatter over generated files anyway, so the in-plugin pass is effectively a double-format for them. This PR lets them opt out.

## What

- `parsePothosOptions` accepts `format=true|false`, defaulting to `true`. `format=false` is the new escape hatch; any other value (including the unset default) is `true`.
- `protocGenPothos.transpile` skips the `formatCode` call entirely when `schema.options.format === false`. The captured flag lives in module-level state because protoplugin's `transpile` callback does not receive the parsed schema — `generateTs` (which does see `schema.options`) populates it on each `plugin.run(req)`, before `transpile` is invoked.
- Default behavior is **unchanged**: every existing call site continues to format, so no snapshot updates are required.

Trade-off when `format=false`:
- generated `.pb.pothos.ts` files keep the raw layout produced by the local printer infrastructure (the `code` template tag in `src/codegen/code-builder.ts`) — functionally identical, just less pretty
- callers are expected to run their own formatter over the output

## Performance

Synthetic fixture (`tmp-profile/`, not committed), 5 iterations average:

| size (messages × fields) | format=true (dprint, default) | format=false (this PR) | speedup |
| --- | ---: | ---: | ---: |
| 10 × 10 (100 fields)     |  12 ms |  4 ms  | 3.5× |
| 25 × 20 (500 fields)     |  40 ms | 11 ms  | 3.6× |
| 50 × 20 (1 000 fields)   |  73 ms | 20 ms  | 3.7× |
| 100 × 20 (2 000 fields)  | 155 ms | 45 ms  | 3.4× |
| 200 × 20 (4 000 fields)  | 353 ms | 78 ms  | 4.5× |
| 400 × 20 (8 000 fields)  | **727 ms** | **169 ms** | **4.3×** |

`ms / field` drops from ~0.09 to ~0.02 — about a 4× reduction in per-field cost.

CPU profile on the 400 × 20 fixture with `format=false`:

| # | function | self time | % |
| ---: | --- | ---: | ---: |
| 1 | (garbage collector) | 707 ms | 14.3 % |
| 2 | `elToContent` (`@bufbuild/protoplugin`) | 454 ms |  9.2 % |
| 3 | `markAsPrintableArray` (`protoc-gen-pothos/src/codegen/code-builder.ts`) | 428 ms |  8.6 % |
| 4 | `escapeString` (`protoc-gen-pothos/src/codegen/helpers.ts`) | 369 ms |  7.4 % |
| 5 | `createZeroMessage` (`@bufbuild/protobuf`) | 315 ms |  6.4 % |
| 6 | `(anonymous)` | 211 ms |  4.3 % |
| 7 | `createFieldRefCode` (`protoc-gen-pothos/src/dslgen/printers/field.ts`) | 191 ms |  3.9 % |
| 8 | `literalOf` (`protoc-gen-pothos/src/codegen/helpers.ts`) | 158 ms |  3.2 % |

No single dominant hotspot — the remaining cost is the actual code generation pipeline.  `formatCode` is **gone** (0 %).

> [!NOTE]
> An earlier revision of this PR description labelled `markAsPrintableArray` / `literalOf` as belonging to `ts-poet`. They are actually in this repository (`src/codegen/code-builder.ts` and `src/codegen/helpers.ts`) — `ts-poet` is not a dependency of `protoc-gen-pothos` or `codegen-core`. The project ships its own template-tag DSL (`code` / `literalOf`) inspired by ts-poet's API but reimplemented locally. The numeric ranking and the conclusion (`formatCode` is gone, distributed cost across the local printer infrastructure) are unchanged.

## Notes for reviewers

- `parsePothosOptions` reads from `rawOptions: { key; value }[]` and returns a typed shape; the new field is added at the top level (`Options.format`), kept out of `printer`/`type` because it controls a post-processing step rather than a code generation choice.
- Tests added in `protoc-plugin-helpers/src/options.test.ts`: default true, explicit true, explicit false, and an invalid value rejection.
- The 6 pre-existing test failures in `tests/golden/*/testapis.oneof/` (`Cannot find module './schema.js'`) are orphan dirs left over from the e2e → golden migration; they fail on `main` too and are unaffected by this PR.

## Relationship to #516

Both PRs target #514. They are **not exclusive**:

- This PR (option) is the simpler change: small surface, biggest win for users who want to bypass formatting.
- #516 (oxfmt swap) is the better default for users who *do* want in-plugin formatting (~2× faster than the current dprint default).

If both land, `format=false` continues to bypass formatting entirely, and the in-plugin path becomes oxfmt instead of dprint. I'd suggest merging this PR first as the bigger no-snapshot-churn win, then reassessing whether #516 is still worth the snapshot churn for the remaining ~2× on the in-plugin path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)