### PR TITLE
perf(protoc-gen-pothos): shrink code-tag output and fast-path PrintableArray marker (~10% with format=false)

### DIFF
--- a/.changeset/perf-code-tag-merge.md
+++ b/.changeset/perf-code-tag-merge.md
@@ -1,0 +1,5 @@
+---
+"protoc-gen-pothos": patch
+---
+
+perf: shrink `code` template-tag output (merge adjacent strings) and switch `markAsPrintableArray` to direct symbol assignment, ~10% faster plugin runs with `format=false`

--- a/packages/protoc-gen-pothos/src/codegen/__tests__/code-builder.test.ts
+++ b/packages/protoc-gen-pothos/src/codegen/__tests__/code-builder.test.ts
@@ -25,12 +25,12 @@ describe("code template tag", () => {
   describe("basic usage", () => {
     test("returns empty array for empty template", () => {
       const result = code``;
-      expect(result).toEqual([""]);
+      expect(printableToString(result)).toBe("");
     });
 
     test("returns string content for template without interpolation", () => {
       const result = code`const x = 1`;
-      expect(result).toEqual(["const x = 1"]);
+      expect(printableToString(result)).toBe("const x = 1");
     });
   });
 

--- a/packages/protoc-gen-pothos/src/codegen/code-builder.ts
+++ b/packages/protoc-gen-pothos/src/codegen/code-builder.ts
@@ -11,12 +11,14 @@ export function isPrintableArray(value: unknown): value is PrintableArray {
 }
 
 export function markAsPrintableArray(arr: Printable[]): PrintableArray {
-  Object.defineProperty(arr, PRINTABLE_ARRAY_MARKER, {
-    value: true,
-    enumerable: false,
-    writable: false,
-    configurable: false,
-  });
+  // Direct symbol-key assignment is ~order-of-magnitude faster than
+  // `Object.defineProperty` because it avoids a hidden-class transition in
+  // V8. Symbol keys do not appear in `for..in` or `Object.keys`, so the
+  // observable semantics (used only by `isPrintableArray`) are unchanged.
+  // NB: structural-equality matchers like Vitest's `toEqual` *do* compare
+  // Symbol-keyed props, so tests that check exact array shape must use the
+  // `printableToString` helper or call `isPrintableArray` explicitly.
+  (arr as PrintableArray)[PRINTABLE_ARRAY_MARKER] = true;
   return arr as PrintableArray;
 }
 
@@ -32,31 +34,59 @@ export function code(
   strings: TemplateStringsArray,
   ...values: CodeValue[]
 ): PrintableArray {
+  // Merge consecutive string-like pieces into a single buffer; only flush the
+  // buffer when we hit something protoplugin needs to see as a distinct
+  // element (ImportSymbol or a nested non-string Printable). This shrinks the
+  // returned array by roughly an order of magnitude for typical printer
+  // output, which cuts the downstream `printableToEl` / `elToContent` /
+  // `processImports` walks proportionally — without changing any semantics
+  // (protoplugin's `f.import(...)` auto-resolution still works because
+  // ImportSymbols surface as their own elements).
   const result: Printable[] = [];
+  let buf = "";
+
+  function flush(): void {
+    if (buf !== "") {
+      result.push(buf);
+      buf = "";
+    }
+  }
 
   for (let i = 0; i < strings.length; i++) {
-    if (strings[i] !== "") {
-      result.push(strings[i]);
-    }
+    buf += strings[i];
 
     if (i < values.length) {
       const value = values[i];
       if (value == null) {
-        result.push(String(value));
+        buf += String(value);
       } else if (typeof value === "string") {
-        if (value !== "") {
-          result.push(value);
-        }
+        buf += value;
       } else if (typeof value === "number") {
-        result.push(String(value));
+        buf += String(value);
       } else if (Array.isArray(value)) {
-        result.push(...value);
+        // Nested Printable[]: fold string-like elements into buf so they merge
+        // with whatever came before/after; only break out for elements
+        // protoplugin must handle (ImportSymbol, further nested arrays).
+        for (const el of value) {
+          if (typeof el === "string") {
+            buf += el;
+          } else if (typeof el === "number" || typeof el === "boolean") {
+            buf += String(el);
+          } else {
+            flush();
+            result.push(el);
+          }
+        }
       } else {
+        // ImportSymbol or another opaque Printable: must remain a distinct
+        // element so the protoplugin walker can resolve it.
+        flush();
         result.push(value as Printable);
       }
     }
   }
 
+  flush();
   if (result.length === 0) {
     result.push("");
   }


### PR DESCRIPTION
## Why

After #518, the next clearly-actionable structural item was the local DSL (`code` template tag + `markAsPrintableArray`) feeding protoplugin's output assembly. The post-#518 CPU profile (400 × 20, format=false) showed:

- `markAsPrintableArray` 7.1 % self (called once per `code\`...\`` invocation, via `Object.defineProperty` → V8 hidden-class transition)
- `elToContent` 10.4 % / `printableToEl` 2.2 % / `processImports` 3.7 % — all of which walk *every element* of every `Printable[]` we hand to `f.print`

This PR is a focused take on shrinking the work for both layers **without giving up `protoplugin`'s `f.import(symbol)` auto-resolution** (which Pure StringBuilder approaches would have to re-implement: dedup, conflict-rename, relative-path resolution).

## What

Two compounding micro-opts in `src/codegen/code-builder.ts`:

1. **`code\`...\`` merges adjacent string-like pieces.** A buffer accumulates strings/numbers/booleans (including elements of nested `Printable[]` returned by other `code\`...\`` calls) and only flushes when something arrives that protoplugin must see as a distinct element — i.e. an `ImportSymbol` or a non-string opaque `Printable`. Result: a typical printer call that produced ~10-15 array elements before now returns 1 (no imports) or ~3–5 (with imports). Protoplugin's walks scale with array length, so this proportionally cuts `printableToEl` / `elToContent` / `processImports` work. Sample sizes verified by `tmp-profile/inspect-elements.mts`:

   ```
   small all-string: 1 elements  (was ~7)
   nested code:      1 elements  (was ~9)
   with import:      5 elements  (was ~9)
   field call:       1 elements  (was ~30+)
   ```

2. **`markAsPrintableArray` switches from `Object.defineProperty` to direct Symbol-key assignment.** Same observable behaviour (the marker is a Symbol so it stays out of `for..in` / `Object.keys`), but avoids the hidden-class transition that made the original a profile hotspot. Two `code-builder.test.ts` tests that previously checked exact array shape via `.toEqual([""])` are switched to the existing `printableToString` helper, because Vitest's structural equality matcher **does** compare Symbol-keyed props.

`protobufGraphQLExtensions`, every printer (`objectType`, `inputObjectType`, `enumType`, `oneofUnionType`, `field`), and the `f.print` / `f.import` integration are all untouched. `Printable[]` remains the IR.

## Performance

Synthetic 400 messages × 20 fields fixture (`tmp-profile/`, not committed), `format=false`, 30-iteration average × three back-to-back runs:

| | run 1 | run 2 | run 3 | average |
| --- | ---: | ---: | ---: | ---: |
| main             | 102.34 ms | 101.41 ms | 102.80 ms | **102.2 ms** |
| this PR          |  94.68 ms |  92.36 ms |  90.12 ms |  **92.4 ms** |
| Δ                |           |           |           | **−9.5 % (~10 ms / run)** |

CPU profile shifts (400 × 20, format=false, 30 iterations):

| function | main | this PR | Δ |
| --- | ---: | ---: | ---: |
| `elToContent` (`@bufbuild/protoplugin`) | 10.4 % | **4.0 %** | **−6.4 %** |
| `printableToEl` (`@bufbuild/protoplugin`) | 2.2 % | (out of top 20) | **−2.2 %** |
| `processImports` (`@bufbuild/protoplugin`) | 3.7 % | 2.5 % | −1.2 % |
| `markAsPrintableArray` (this repo) | 7.1 % | (negligible after direct-assign + fewer calls) | substantial |
| `code` (this repo) | 2.2 % | 1.8 % | −0.4 % |

`f.import(...)` auto-resolution is fully preserved — ImportSymbols still surface as distinct elements in the returned arrays, so protoplugin tracks them as before.

## Notes for reviewers

- **All golden + unit snapshots are byte-identical to `main`** (`git diff --stat tests/golden/ packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/` → empty). The change reorganises *how* we build the `Printable[]` but produces the same flattened output.
- The 6 pre-existing test failures in `tests/golden/*/testapis.oneof/` (`Cannot find module './schema.js'`) are orphan dirs from the e2e → golden migration and are unaffected.
- A WeakSet-based implementation of the marker was tried (instead of direct symbol assignment) but turned out *slower* than the original `Object.defineProperty` (~110 ms vs ~102 ms); the symbol-key approach with the test-side helper update is the practical sweet spot.

## Why not "Pure StringBuilder"?

I explored a separate Pure StringBuilder design (drop `Printable[]`, do imports ourselves, build a single string per file). The lower-bound experiment (`f.print(captured-string)`) showed an absolute ceiling of ~31 ms vs current ~95 ms, but a realistic Pure SB would land closer to 60-70 ms — call it ~+10-12 % beyond this PR — at the cost of ~700 LOC across ~10 files, manual import deduplication / conflict-rename / relative-path resolution, and giving up protoplugin's `f.import` integration. This PR captures ~half of that potential delta at <5 % of the LOC cost and with zero API change, leaving Pure SB available as a follow-up if the remaining +10 % is worth its own scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)