### PR TITLE
perf(codegen-core): share frozen empty `[graphql.*]` option defaults (~27% with format=false)

### DIFF
--- a/.changeset/perf-cache-empty-options.md
+++ b/.changeset/perf-cache-empty-options.md
@@ -1,0 +1,5 @@
+---
+"@proto-graphql/codegen-core": patch
+---
+
+perf: cache frozen empty-default `[graphql.*]` option messages to remove `createZeroMessage` allocations on every descriptor lookup, ~27% faster `protoc-gen-pothos` runs with `format=false`

--- a/packages/@proto-graphql/codegen-core/src/types/util.ts
+++ b/packages/@proto-graphql/codegen-core/src/types/util.ts
@@ -330,54 +330,77 @@ export function descriptionFromProto(proto: CommentedDesc): string | null {
   return getCommentsFor(proto).leading?.trim() || null;
 }
 
+// Frozen, shared "no options set" defaults for each extension type. The
+// `proto.options == null` branch fires on every descriptor that doesn't carry
+// any `[graphql.*]` option in its `.proto` source — i.e. the common case —
+// and each call site below would otherwise allocate a fresh empty message via
+// `create(...)`. On a synthetic 400-message x 20-field fixture that path
+// dominated CPU profiles (`createZeroMessage` 9.3% self time). All call sites
+// read the returned object; nothing mutates it, so a single frozen instance
+// is safe to share across the entire plugin run.
+const EMPTY_SCHEMA_OPTIONS = Object.freeze(
+  create(extensions.GraphqlSchemaOptionsSchema, {}),
+);
+const EMPTY_OBJECT_TYPE_OPTIONS = Object.freeze(
+  create(extensions.GraphqlObjectTypeOptionsSchema, {}),
+);
+const EMPTY_INPUT_TYPE_OPTIONS = Object.freeze(
+  create(extensions.GraphqlInputTypeOptionsSchema, {}),
+);
+const EMPTY_FIELD_OPTIONS = Object.freeze(
+  create(extensions.GraphqlFieldOptionsSchema, {}),
+);
+const EMPTY_ONEOF_OPTIONS = Object.freeze(
+  create(extensions.GraphqlOneofOptionsSchema, {}),
+);
+const EMPTY_ENUM_OPTIONS = Object.freeze(
+  create(extensions.GraphqlEnumOptionsSchema, {}),
+);
+const EMPTY_ENUM_VALUE_OPTIONS = Object.freeze(
+  create(extensions.GraphqlEnumValueOptionsSchema, {}),
+);
+
 function getSchemaOptions(
   desc: DescMessage | DescEnum,
 ): extensions.GraphqlSchemaOptions {
-  if (desc.file.proto.options == null)
-    return create(extensions.GraphqlSchemaOptionsSchema, {});
+  if (desc.file.proto.options == null) return EMPTY_SCHEMA_OPTIONS;
   return getExtension(desc.file.proto.options, extensions.schema);
 }
 
 function getObjectTypeOptions(
   desc: DescMessage,
 ): extensions.GraphqlObjectTypeOptions {
-  if (desc.proto.options == null)
-    return create(extensions.GraphqlObjectTypeOptionsSchema, {});
+  if (desc.proto.options == null) return EMPTY_OBJECT_TYPE_OPTIONS;
   return getExtension(desc.proto.options, extensions.object_type);
 }
 
 export function getInputTypeOptions(
   desc: DescMessage,
 ): extensions.GraphqlInputTypeOptions {
-  if (desc.proto.options == null)
-    return create(extensions.GraphqlInputTypeOptionsSchema, {});
+  if (desc.proto.options == null) return EMPTY_INPUT_TYPE_OPTIONS;
   return getExtension(desc.proto.options, extensions.input_type);
 }
 
 export function getFieldOptions(
   desc: DescField,
 ): extensions.GraphqlFieldOptions {
-  if (desc.proto.options == null)
-    return create(extensions.GraphqlFieldOptionsSchema, {});
+  if (desc.proto.options == null) return EMPTY_FIELD_OPTIONS;
   return getExtension(desc.proto.options, extensions.field);
 }
 
 function getOneofOptions(desc: DescOneof): extensions.GraphqlOneofOptions {
-  if (desc.proto.options == null)
-    return create(extensions.GraphqlOneofOptionsSchema, {});
+  if (desc.proto.options == null) return EMPTY_ONEOF_OPTIONS;
   return getExtension(desc.proto.options, extensions.oneof);
 }
 
 function getEnumTypeOptions(desc: DescEnum): extensions.GraphqlEnumOptions {
-  if (desc.proto.options == null)
-    return create(extensions.GraphqlEnumOptionsSchema, {});
+  if (desc.proto.options == null) return EMPTY_ENUM_OPTIONS;
   return getExtension(desc.proto.options, extensions.enum_type);
 }
 
 function getEnumValueOptions(
   desc: DescEnumValue,
 ): extensions.GraphqlEnumValueOptions {
-  if (desc.proto.options == null)
-    return create(extensions.GraphqlEnumValueOptionsSchema, {});
+  if (desc.proto.options == null) return EMPTY_ENUM_VALUE_OPTIONS;
   return getExtension(desc.proto.options, extensions.enum_value);
 }


### PR DESCRIPTION
## Why

After #519, the post-`format=false` CPU profile (400 × 20 fixture) showed `createZeroMessage` as the single biggest remaining hotspot at **9.3 % self time**, with `create` and the reflect helpers behind it. Tracing parents confirmed it was driven almost entirely by `codegen-core/src/types/util.ts` — specifically, the `proto.options == null` branch in the seven `get*Options` accessors:

```ts
function getFieldOptions(desc) {
  if (desc.proto.options == null)
    return create(extensions.GraphqlFieldOptionsSchema, {});  // fresh alloc per call
  return getExtension(desc.proto.options, extensions.field);
}
```

A `.proto` file that doesn't carry any `[graphql.*]` annotations — i.e. the common case — hits this branch on every descriptor lookup. `getFieldOptions` alone is invoked 3–5× per field via `isRequiredField` / `isInputOnlyField` / `isOutputOnlyField` / direct printer use, so a 4000-field workload paid 12k–20k fresh empty-message allocations. Same shape for message, schema, oneof, enum and enum-value accessors.

## What

Replace each `proto.options == null` branch with a single `Object.freeze(create(...Schema, {}))` constant allocated once at module import time. Every existing call site only reads the returned object (`opts.ignore`, `opts.inputNullability`, `opts.typePrefix`, …), so a shared frozen instance is safe.

```ts
const EMPTY_FIELD_OPTIONS = Object.freeze(
  create(extensions.GraphqlFieldOptionsSchema, {}),
);

export function getFieldOptions(desc: DescField): extensions.GraphqlFieldOptions {
  if (desc.proto.options == null) return EMPTY_FIELD_OPTIONS;
  return getExtension(desc.proto.options, extensions.field);
}
```

Same pattern for `GraphqlSchemaOptions`, `GraphqlObjectTypeOptions`, `GraphqlInputTypeOptions`, `GraphqlOneofOptions`, `GraphqlEnumOptions`, and `GraphqlEnumValueOptions`. The `getExtension(...)` path (used when an extension is actually set) is unchanged.

## Performance

Synthetic 400 messages × 20 fields fixture (`tmp-profile/`, not committed), 30-iteration average × three back-to-back runs:

| | run 1 | run 2 | run 3 | average | Δ |
| --- | ---: | ---: | ---: | ---: | ---: |
| main, `format=false`             | 92.42 ms | 93.08 ms | 93.77 ms | **93.1 ms** | — |
| this PR, `format=false`          | 67.35 ms | 67.68 ms | 68.01 ms | **67.7 ms** | **−27 %** |
| main, `format=true` (dprint)     | 1054.89 ms | 1020.21 ms | 1014.30 ms | **1029.8 ms** | — |
| this PR, `format=true` (dprint)  |  988.29 ms |  975.17 ms |  984.05 ms |  **982.5 ms** | **−4.6 %** |

`format=true` users still get the smaller savings — the formatter dominates that path so a 25 ms codegen saving turns into 4–5 % wall-clock.

CPU profile (400 × 20, format=false, 30 iterations), top entries:

| function | main | this PR | Δ |
| --- | ---: | ---: | ---: |
| `createZeroMessage` (`@bufbuild/protobuf`) | 9.30 % | **1.87 %** | **−7.4 %** |
| `create` (`@bufbuild/protobuf`)            | 1.32 % | (out of top 20) | substantial |
| total CPU                                  | 4580 ms | **3825 ms** | **−16 %** |
| (garbage collector)                        | 14.8 % | 16.5 % | proportionally up (smaller pool) but absolute pressure roughly unchanged |

The remaining `createZeroMessage` (1.9 %) is the `ReflectMessageImpl` path that runs inside `getExtension(...)` when an option *is* set — not addressable without changing protobuf-es.

## Notes for reviewers

- **All golden + unit snapshots are byte-identical to `main`** (`git diff --stat tests/golden/ packages/protoc-gen-pothos/src/dslgen/printers/__snapshots__/` → empty).
- The 6 pre-existing test failures in `tests/golden/*/testapis.oneof/` (`Cannot find module './schema.js'`) are orphan dirs from the e2e → golden migration and are unaffected.
- The `_exhaustiveCheck` "declared but never read" lint notices on `util.ts` are pre-existing (visible on `main` too) — they sit on unrelated lines and weren't touched here.
- `protoc-gen-pothos` doesn't change but is the user-visible beneficiary; the changeset bumps `@proto-graphql/codegen-core` as `patch` since the change is internal/perf with no API surface change.

## Why patch and not include #514's "B" (`getCommentsFor` memo)?

The earlier proposal also flagged caching the materialised `Comments` object inside `getCommentsFor`. On the post-#519 profile that lever sits at ~1.9 % self and would carry its own WeakMap branch in a hot path; it was de-scoped for now in favour of shipping A alone and re-measuring. If a follow-up shows the cost is still meaningful after this PR lands, we can revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)